### PR TITLE
[RFC] add notify based file system event monitor

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ var (
 		ScanInterval:           30,
 		CheckInterval:          1,
 		RepositoryScanInterval: 5,
+		EventBufferSize:        10000,
 		Hashes: hashing{
 			SHA1:   true,
 			SHA256: false,
@@ -54,6 +55,7 @@ type configuration struct {
 	ScanInterval            int        `yaml:"ScanInterval"`
 	CheckInterval           int        `yaml:"CheckInterval"`
 	RepositoryScanInterval  int        `yaml:"RepositoryScanInterval"`
+	EventBufferSize         int        `yaml:"EventBufferSize"`
 	Hashes                  hashing    `yaml:"Hashes"`
 	DisallowRedirects       bool       `yaml:"DisallowRedirects"`
 	WeightDistributionRange float32    `yaml:"WeightDistributionRange"`

--- a/eventmonitor.go
+++ b/eventmonitor.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2015 wsnipex
+// Licensed under the MIT license
+
+package main
+
+import (
+	"github.com/rjeczalik/notify"
+	"sync"
+)
+
+type EventMonitor struct {
+	redis    *redisobj
+	cache    *Cache
+	mapLock  sync.Mutex
+	syncChan chan string
+	stop     chan bool
+	wg       sync.WaitGroup
+	buffer   chan notify.EventInfo
+}
+
+func NewEventMonitor(r *redisobj, c *Cache) *EventMonitor {
+	fsmon := new(EventMonitor)
+	fsmon.redis = r
+	fsmon.cache = c
+	fsmon.syncChan = make(chan string)
+	fsmon.stop = make(chan bool)
+
+	bufsize := GetConfig().EventBufferSize
+	if bufsize < 1000 {
+		bufsize = 1000
+		log.Warning("EventBuffersize too low, adjusting to 1000")
+	}
+	fsmon.buffer = make(chan notify.EventInfo, bufsize)
+
+	return fsmon
+}
+
+func (m *EventMonitor) Stop() {
+	select {
+	case _, _ = <-m.stop:
+		return
+	default:
+		close(m.stop)
+	}
+}
+
+func (m *EventMonitor) Wait() {
+	m.wg.Wait()
+}
+
+func (m *EventMonitor) MonitorRepository() {
+	var path string
+
+	// set up a recursive watch on our repository
+	path = GetConfig().Repository + "/..."
+	if err := notify.Watch(path, m.buffer, notify.All); err != nil {
+		log.Fatal(err)
+	}
+	defer notify.Stop(m.buffer)
+
+	for {
+		ei := <-m.buffer
+		ScanFile(m.redis, ei.Path(), ei.Event().String())
+	}
+}


### PR DESCRIPTION
Disclaimer: This is my first ever go at Go(sic), so please assume I don't know what I'm doing

while we were running into the constant local repository scan (#18) we figured that it'd be more efficient to use filesystem events instead of file system crawling.
Although this bug has been fixed, I wanted to see if event based local repo scanning is feasible.

This PR implements a POC for this, built on the cross platform notify lib, which under the hood uses native OS implementations. On linux this currently is inotify.
The reason not to use inotify directly is that it does not support recursive watch points.

I've not tested this yet in production, but it seems to work on my simple test setup.
Before I put more effort in it, I'd like your opinion on the general approach and ofc if you would accept it.

Note that this doesn't necessarily replace the local repo monitor, it can happily live besides.
