### PR TITLE
fix filestats period passing

### DIFF
--- a/http.go
+++ b/http.go
@@ -344,9 +344,12 @@ func (h *HTTP) fileStatsHandler(w http.ResponseWriter, r *http.Request, ctx *Con
 		if e == "" {
 			continue
 		}
-		if _, err := strconv.ParseInt(e, 10, 0); err != nil {
-			http.Error(w, "Invalid period", http.StatusBadRequest)
-			return
+		z := strings.SplitN(e, "_", 3)
+		for _, sub := range z {
+			if _, err := strconv.ParseInt(sub, 10, 0); err != nil || len(sub) > 4 {
+				http.Error(w, "Invalid period", http.StatusBadRequest)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Its currently not possible to pass a period to file stats
e.g. http://mirrors.kodi.tv/releases/win32/kodi-15.1-Isengard.exe?stats=2015_08_18 results in "Invalid period"
