### PR TITLE
Add global download statistics

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ var (
 		RedisPassword:          "",
 		LogDir:                 "",
 		GeoipDatabasePath:      "/usr/share/GeoIP/",
+		DownloadStatsPath:      "",
 		ConcurrentSync:         2,
 		ScanInterval:           30,
 		CheckInterval:          1,
@@ -59,6 +60,7 @@ type configuration struct {
 	WeightDistributionRange float32    `yaml:"WeightDistributionRange"`
 	DisableOnMissingFile    bool       `yaml:"DisableOnMissingFile"`
 	Fallbacks               []fallback `yaml:"Fallbacks"`
+	DownloadStatsPath       string     `yaml:"DownloadStatsPath"`
 
 	RedisSentinelMasterName string      `yaml:"RedisSentinelMasterName"`
 	RedisSentinels          []sentinels `yaml:"RedisSentinels"`

--- a/context.go
+++ b/context.go
@@ -16,6 +16,7 @@ const (
 	MIRRORLIST
 	FILESTATS
 	MIRRORSTATS
+	DOWNLOADSTATS
 	CHECKSUM
 )
 
@@ -29,6 +30,7 @@ type Context struct {
 	isMirrorList  bool
 	isMirrorStats bool
 	isFileStats   bool
+	isDlStats     bool
 	isChecksum    bool
 	isPretty      bool
 }
@@ -37,6 +39,13 @@ type Context struct {
 func NewContext(w http.ResponseWriter, r *http.Request, t Templates) *Context {
 	c := &Context{r: r, w: w, t: t, v: r.URL.Query()}
 
+	if len(GetConfig().DownloadStatsPath) > 0 && r.URL.Path == GetConfig().DownloadStatsPath {
+		if c.paramBool("downloadstats") {
+			c.typ = DOWNLOADSTATS
+			c.isDlStats = true
+			return c
+		}
+	}
 	if c.paramBool("mirrorlist") {
 		c.typ = MIRRORLIST
 		c.isMirrorList = true
@@ -93,6 +102,11 @@ func (c *Context) IsFileStats() bool {
 // IsMirrorStats returns true if the mirror stats has been requested
 func (c *Context) IsMirrorStats() bool {
 	return c.isMirrorStats
+}
+
+// IsDownloadStats returns true if the download stats have been requested
+func (c *Context) IsDownloadStats() bool {
+	return c.isDlStats
 }
 
 // IsChecksum returns true if a checksum has been requested

--- a/templates/downloadstats.html
+++ b/templates/downloadstats.html
@@ -1,0 +1,16 @@
+{{define "title"}}Downloadstats{{end}}
+{{define "headline"}}{{if .Limit}}Top {{.Limit}}{{end}} Downloads {{.Period}}{{end}}
+
+{{define "head"}}{{end}}
+
+{{define "body"}}
+<a href="{{.Path}}?downloadstats">All Time</a> <a href="{{.Path}}?downloadstats={{.Month}}">This Month</a> <a href="/stats?downloadstats={{.Today}}">Today</a>
+<table>
+<thead><tr><th>Filename</th><th>Downloads</th></tr></thead>
+<tbody>
+{{range $v := .List}}
+<tr><td>{{$v.Filename}}</td><td>{{$v.Downloads}}</td></tr>
+{{end}}
+</tbody>
+</table>
+{{end}}

--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
@@ -313,4 +314,30 @@ func timeKeyCoverage(start, end time.Time) (dates []string) {
 	}
 
 	return
+}
+
+// Int64 Sort utility functions
+// Copyright (c) 2014 The sortutil Authors, https://github.com/cznic/sortutil/blob/master/sortutil.go#L144
+
+// Int64Slice attaches the methods of sort.Interface to []int64
+type Int64Slice []int64
+
+func (s Int64Slice) Len() int {
+	return len(s)
+}
+
+func (s Int64Slice) Less(i, j int) bool {
+	return s[i] < s[j]
+}
+
+func (s Int64Slice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Int64Slice) Sort() {
+	sort.Sort(s)
+}
+
+func (s Int64Slice) Reverse() {
+	sort.Sort(sort.Reverse(s))
 }


### PR DESCRIPTION
This adds a new handler in http.go that uses existing file download statistics to show a global download statistics page.
We have this running on our server for a while: http://mirrors.kodi.tv/stats?downloadstats
- downloadstats param takes the same optional date format as ?stats (period)
- simple filename filter(no wildcards atm): &filter=example
- limit parameter that limits results returned: &limit=[int]
  default=100
  set to 0 to disable
- optional json output: &format=json

examples:
http://mirrors.kodi.tv/stats?downloadstats=2015-08-17 <- all DLs from yesterday(17th August)
http://mirrors.kodi.tv/stats?downloadsta...oviedb.org <- all DLs from Juli containing metadata.themoviedb.org in the file path

The template file could use some web dev hands on, its currently very basic.
