### PR TITLE
rsync: exclude default partialdir

### DIFF
--- a/scan/rsync.go
+++ b/scan/rsync.go
@@ -56,7 +56,7 @@ func (r *RsyncScanner) Scan(rsyncURL, identifier string, conn redis.Conn, stop c
 	// Don't use the local timezone, use UTC
 	env = append(env, "TZ=UTC")
 
-	cmd := exec.Command("rsync", "-r", "--no-motd", "--timeout=30", "--contimeout=30", u.String())
+	cmd := exec.Command("rsync", "-r", "--no-motd", "--timeout=30", "--contimeout=30", "--exclude=.~tmp~/", u.String())
 
 	// Setup the environnement
 	cmd.Env = env


### PR DESCRIPTION
Some mirrors fail syncing with `... rsync: exit status 23`
After trying to rsync them manually I found the following for some mirrors, `rsync: opendir ".../.~tmp~" (in xbmc) failed: Permission denied (13)`
`.~tmp~` is the default partialdir of rsync, excluding it solved the issue.

It is already running on http://mirrors.kodi.tv, but you can't see any changes on the website.