### PR TITLE
Add SHA3_512 support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,9 +93,10 @@ type sentinels struct {
 }
 
 type hashing struct {
-	SHA1   bool `yaml:"SHA1"`
-	SHA256 bool `yaml:"SHA256"`
-	MD5    bool `yaml:"MD5"`
+	SHA1     bool `yaml:"SHA1"`
+	SHA256   bool `yaml:"SHA256"`
+	SHA3_512 bool `yaml:"SHA3_512"`
+	MD5      bool `yaml:"MD5"`
 }
 
 // LoadConfig loads the configuration file if it has not yet been loaded

--- a/filesystem/fileinfo.go
+++ b/filesystem/fileinfo.go
@@ -10,12 +10,13 @@ import (
 // FileInfo is a struct embedding details about a file served by
 // the redirector.
 type FileInfo struct {
-	Path    string    `redis:"-"`
-	Size    int64     `redis:"size" json:",omitempty"`
-	ModTime time.Time `redis:"modTime" json:",omitempty"`
-	Sha1    string    `redis:"sha1" json:",omitempty"`
-	Sha256  string    `redis:"sha256" json:",omitempty"`
-	Md5     string    `redis:"md5" json:",omitempty"`
+	Path     string    `redis:"-"`
+	Size     int64     `redis:"size" json:",omitempty"`
+	ModTime  time.Time `redis:"modTime" json:",omitempty"`
+	Sha1     string    `redis:"sha1" json:",omitempty"`
+	Sha256   string    `redis:"sha256" json:",omitempty"`
+	Sha3_512 string    `redis:"sha3_512" json:",omitempty"`
+	Md5      string    `redis:"md5" json:",omitempty"`
 }
 
 // NewFileInfo returns a new FileInfo object

--- a/filesystem/hash.go
+++ b/filesystem/hash.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"os"
 
+	"golang.org/x/crypto/sha3"
+
 	. "github.com/etix/mirrorbits/config"
 )
 
@@ -42,6 +44,11 @@ func HashFile(path string) (hashes FileInfo, err error) {
 		hmd5 := newHasher(md5.New(), &hashes.Md5)
 		defer hmd5.Close()
 		writers = append(writers, hmd5)
+	}
+	if GetConfig().Hashes.SHA3_512 {
+		hsha3_512 := newHasher(sha3.New512(), &hashes.Sha3_512)
+		defer hsha3_512.Close()
+		writers = append(writers, hsha3_512)
 	}
 
 	if len(writers) == 0 {

--- a/http/context.go
+++ b/http/context.go
@@ -54,7 +54,7 @@ func NewContext(w http.ResponseWriter, r *http.Request, t Templates) *Context {
 	} else if c.paramBool("mirrorstats") {
 		c.typ = MIRRORSTATS
 		c.isMirrorStats = true
-	} else if c.paramBool("md5") || c.paramBool("sha1") || c.paramBool("sha256") {
+	} else if c.paramBool("md5") || c.paramBool("sha1") || c.paramBool("sha256") || c.paramBool("sha3_512") {
 		c.typ = CHECKSUM
 		c.isChecksum = true
 	} else {

--- a/http/http.go
+++ b/http/http.go
@@ -450,6 +450,8 @@ func (h *HTTP) checksumHandler(w http.ResponseWriter, r *http.Request, ctx *Cont
 		hash = fileInfo.Sha1
 	} else if ctx.paramBool("sha256") {
 		hash = fileInfo.Sha256
+	} else if ctx.paramBool("sha3_512") {
+		hash = fileInfo.Sha3_512
 	}
 
 	if len(hash) == 0 {

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -23,6 +23,7 @@ CheckInterval: 1
 RepositoryScanInterval: 5
 Hashes:
     SHA256: On
+    SHA3_512: Off
     SHA1: Off
     MD5: Off
 DisallowRedirects: false

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -23,7 +23,7 @@ CheckInterval: 1
 RepositoryScanInterval: 5
 Hashes:
     SHA256: On
-    SHA3_512: Off
+    SHA3_512: On
     SHA1: Off
     MD5: Off
 DisallowRedirects: false

--- a/mirrors/cache.go
+++ b/mirrors/cache.go
@@ -146,7 +146,7 @@ func (c *Cache) fetchFileInfo(path string) (f filesystem.FileInfo, err error) {
 	defer rconn.Close()
 	f.Path = path // Path is not stored in the object instance in redis
 
-	reply, err := redis.Strings(rconn.Do("HMGET", fmt.Sprintf("FILE_%s", path), "size", "modTime", "sha1", "sha256", "md5"))
+	reply, err := redis.Strings(rconn.Do("HMGET", fmt.Sprintf("FILE_%s", path), "size", "modTime", "sha1", "sha256", "md5", "sha3_512"))
 	if err != nil {
 		return
 	}
@@ -156,6 +156,7 @@ func (c *Cache) fetchFileInfo(path string) (f filesystem.FileInfo, err error) {
 	f.Sha1 = reply[2]
 	f.Sha256 = reply[3]
 	f.Md5 = reply[4]
+	f.Sha3_512 = reply[5]
 	c.fiCache.Set(path, &fileInfoValue{value: f})
 	return
 }
@@ -252,7 +253,7 @@ func (c *Cache) fetchFileInfoMirror(id, path string) (f filesystem.FileInfo, err
 	defer rconn.Close()
 	f.Path = path // Path is not stored in the object instance in redis
 
-	reply, err := redis.Strings(rconn.Do("HMGET", fmt.Sprintf("FILEINFO_%s_%s", id, path), "size", "modTime", "sha1", "sha256", "md5"))
+	reply, err := redis.Strings(rconn.Do("HMGET", fmt.Sprintf("FILEINFO_%s_%s", id, path), "size", "modTime", "sha1", "sha256", "md5", "sha3_512"))
 	if err != nil {
 		return
 	}
@@ -265,6 +266,7 @@ func (c *Cache) fetchFileInfoMirror(id, path string) (f filesystem.FileInfo, err
 	f.Sha1 = reply[2]
 	f.Sha256 = reply[3]
 	f.Md5 = reply[4]
+	f.Sha3_512 = reply[5]
 
 	c.fimCache.Set(fmt.Sprintf("%s|%s", id, path), &fileInfoValue{value: f})
 	return

--- a/templates/mirrorlist.html
+++ b/templates/mirrorlist.html
@@ -46,6 +46,7 @@
                 <tr><td>MD5</td><td style="font-family: monospace; word-break: break-all;">{{if .FileInfo.Md5}}{{.FileInfo.Md5}}{{else}}N/A{{end}}</td></tr>
                 <tr><td>SHA1</td><td style="font-family: monospace; word-break: break-all;">{{if .FileInfo.Sha1}}{{.FileInfo.Sha1}}{{else}}N/A{{end}}</td></tr>
                 <tr><td>SHA256</td><td style="font-family: monospace; word-break: break-all;">{{if .FileInfo.Sha256}}{{.FileInfo.Sha256}}{{else}}N/A{{end}}</td></tr>
+                <tr><td>SHA3-512</td><td style="font-family: monospace; word-break: break-all;">{{if .FileInfo.Sha3_512}}{{.FileInfo.Sha3_512}}{{else}}N/A{{end}}</td></tr>
             </table>
         </div>
         <br/>

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,6 +51,12 @@
 			"revisionTime": "2017-10-17T00:29:02Z"
 		},
 		{
+			"checksumSHA1": "iNE2KX9BQzCptlQC2DdQEVmn4R4=",
+			"path": "golang.org/x/crypto/sha3",
+			"revision": "a6600008915114d9c087fad9f03d75087b1a74df",
+			"revisionTime": "2018-01-19T09:51:11Z"
+		},
+		{
 			"checksumSHA1": "/vc89vae+AsvNTGofKHOmmGRUfU=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "8dbc5d05d6edcc104950cc299a1ce6641235bc86",


### PR DESCRIPTION
Hi,

Right now mirrorbits supports MD5, SHA1, and SHA256 as hash formats. Of these, only SHA256 is considered secure. It would be prudent to support additional secure hash formats in case of any future developments in hash attacks.

This series adds SHA3_512 as an extra hash format to mirrorbits.

Like SHA2, SHA3 has a lot of variants that are summarized [on Wikipedia](https://en.wikipedia.org/wiki/SHA-3#Comparison_of_SHA_functions); my understanding is that SHA3_512 provides the best security. 

It's using the golang.org/x/crypto implementation which I believe to be high-quality. You may need to run `govendor sync` before building.

There's no tests (in line with the existing hash support) but everything seems to work when I try it out.

In future, the hash format system should be redesigned to drop-in additional hash types, instead of having to add it in several places; and the redis keys should be centralized somewhere instead of repeated ad-hoc throughout the codebase.

I added SHA3_512 as a default in the configuration file, but since that would cause some workload for existing installations, i'm OK with skipping that patch if you want.

Somewhat motivated by [[1]](https://www.reddit.com/r/LineageOS/comments/6z8h9w/stop_providing_weak_checksum_hashes/), but no relation.

Regards
mappu