### PR TITLE
Switch mirrorlist to use OSM instead of Google Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Option | description
 ------ | -----------
 Repository | Path to your own copy of the repository
 Templates | Path containing the templates
-GoogleMapsAPIKey | Google Maps API key that you can [obtain here](https://developers.google.com/maps/documentation/javascript/get-api-key).
 OutputMode | auto: based on the *Accept* header content<br>redirect: do an HTTP redirect to the destination<br>json: return a JSON formatted document (also known as API mode)
 ListenAddress | Local address and port to bind
 Gzip | Use gzip compression for the JSON responses

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,6 @@ var (
 		DisallowRedirects:       false,
 		WeightDistributionRange: 1.5,
 		DisableOnMissingFile:    false,
-		GoogleMapsAPIKey:        "",
 	}
 	config      *Configuration
 	configMutex sync.RWMutex
@@ -78,8 +77,6 @@ type Configuration struct {
 
 	RedisSentinelMasterName string      `yaml:"RedisSentinelMasterName"`
 	RedisSentinels          []sentinels `yaml:"RedisSentinels"`
-
-	GoogleMapsAPIKey string `yaml:"GoogleMapsAPIKey"`
 }
 
 type fallback struct {

--- a/contrib/docker/mirrorbits.conf
+++ b/contrib/docker/mirrorbits.conf
@@ -2,7 +2,6 @@
 
 Repository: /srv/repo
 Templates: /go/src/github.com/etix/mirrorbits/templates/
-GoogleMapsAPIKey:
 OutputMode: auto
 ListenAddress: :8080
 Gzip: false

--- a/http/pagerenderer.go
+++ b/http/pagerenderer.go
@@ -120,8 +120,6 @@ func (w *MirrorListRenderer) Write(ctx *Context, results *mirrors.Results) (stat
 	// Create a temporary output buffer to render the page
 	var buf bytes.Buffer
 
-	// Generate the URL for the map
-	results.MapURL = mirrors.GetMirrorMapURL(results.MirrorList, results.ClientInfo)
 	ctx.ResponseWriter().Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	// Render the page into the buffer

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -2,7 +2,6 @@
 
 Repository: /srv/repo
 Templates: /usr/share/mirrorbits/
-GoogleMapsAPIKey: <insert-api-key>
 OutputMode: json
 ListenAddress: :8080
 Gzip: false

--- a/mirrors/mirrors_test.go
+++ b/mirrors/mirrors_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/etix/geoip"
-	"github.com/etix/mirrorbits/config"
 	"github.com/etix/mirrorbits/database"
 	"github.com/etix/mirrorbits/network"
 	. "github.com/etix/mirrorbits/testing"
@@ -520,65 +519,3 @@ func TestSetMirrorState(t *testing.T) {
 	}
 }
 
-func TestGetMirrorMapUrl(t *testing.T) {
-	config.SetConfiguration(&config.Configuration{})
-
-	m := Mirrors{
-		Mirror{
-			ID:        "M0",
-			Latitude:  -80.0,
-			Longitude: 80.0,
-		},
-		Mirror{
-			ID:        "M1",
-			Latitude:  -60.0,
-			Longitude: 60.0,
-		},
-		Mirror{
-			ID:        "M2",
-			Latitude:  -40.0,
-			Longitude: 40.0,
-		},
-		Mirror{
-			ID:        "M3",
-			Latitude:  -20.0,
-			Longitude: 20.0,
-		},
-	}
-
-	c := network.GeoIPRecord{
-		GeoIPRecord: &geoip.GeoIPRecord{
-			Latitude:  -10.0,
-			Longitude: 10.0,
-		},
-		ASNum: 4444,
-	}
-
-	result := GetMirrorMapURL(m, c)
-
-	if !strings.HasPrefix(result, "//maps.googleapis.com") {
-		t.Fatalf("Bad format")
-	}
-
-	if !strings.Contains(result, "color:red") {
-		t.Fatalf("Missing client marker?")
-	}
-
-	if strings.Count(result, "label:") != len(m) {
-		t.Fatalf("Missing some mirror markers?")
-	}
-
-	if strings.Contains(result, "key=") {
-		t.Fatalf("Result should not contain an api key")
-	}
-
-	config.SetConfiguration(&config.Configuration{
-		GoogleMapsAPIKey: "qwerty",
-	})
-
-	result = GetMirrorMapURL(m, c)
-
-	if !strings.Contains(result, "key=qwerty") {
-		t.Fatalf("Result must contain the api key")
-	}
-}

--- a/templates/mirrorlist.html
+++ b/templates/mirrorlist.html
@@ -26,6 +26,45 @@
             chart.draw(data, options);
          }
     </script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.2/leaflet.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.0/MarkerCluster.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.2/leaflet.js"></script>
+    <style>
+    .numberboxinmapblue {
+      background:blue; color:white; border:none;
+      text-align:center;
+      font-size: 11px;
+      min-height: 16px; min-width: 16px;
+    }
+    .numberboxinmapblue:after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      width: 0; height: 0;
+      border: 4px solid transparent;
+      border-top-color: blue;
+      border-bottom: 0;
+      margin-left: -4px; margin-bottom: -4px;
+    }
+    .numberboxinmapgreen {
+      background:green; color:white; border:none;
+      text-align:center;
+      font-size: 11px;
+      min-height: 16px; min-width: 16px;
+    }
+    .numberboxinmapgreen:after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      width: 0; height: 0;
+      border: 4px solid transparent;
+      border-top-color: green;
+      border-bottom: 0;
+      margin-left: -4px; margin-bottom: -4px;
+    }
+    </style>
 {{end}}
 
 {{define "body"}}
@@ -53,9 +92,73 @@
 </div>
 
 <div style="display: flex; flex-wrap: wrap; justify-content: space-around;">
-    <div style=""><img style="border: 1px grey;"  width="600" height="320" src="{{.MapURL}}"/></div>
+    <div id="map" style="width:600; height:320;"></div>
     <div id="chart_div" style="width:600; height:320;"></div>
 </div>
+
+<script>
+    var map = L.map('map').setView([20,37], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>, map rendering <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+    }).addTo(map);
+
+    var mapdata = {
+        "mirrors" : [
+        {{range $i, $v := .MirrorList}}{{if lt $i 19 }}
+        {
+            "lat" : {{$v.Latitude}},
+            "lon" : {{$v.Longitude}},
+            "nr" : {{add $i 1}},
+            "color" : {{if $v.Weight}}"green"{{else}}"blue"{{end}}
+        },
+        {{end}}{{end}}
+        ],
+        "clientpos" : {
+            {{if .ClientInfo.GeoIPRecord}}
+            "lat" : {{.ClientInfo.Latitude}},
+            "lon" : {{.ClientInfo.Longitude}}
+            {{else}}
+            "lat" : 0.0,
+            "lon" : 0.0
+            {{end}}
+        }
+    };
+    var latlngbounds = new L.latLngBounds(); // For calculating the boundaries we zoom to on map load
+    if ((mapdata.clientpos.lat != 0.0) || (mapdata.clientpos.lon != 0.0)) {
+        var nxtmarker = new L.marker([mapdata.clientpos.lat, mapdata.clientpos.lon]);
+        nxtmarker.addTo(map);
+        latlngbounds.extend([mapdata.clientpos.lat, mapdata.clientpos.lon]);
+        if (mapdata.mirrors.length > 0) {
+            var polyline = L.polyline( [
+                                         [ mapdata.clientpos.lat, mapdata.clientpos.lon ],
+                                         [ mapdata.mirrors[0].lat, mapdata.mirrors[0].lon ]
+                                       ],
+                                       {color: 'blue', opacity: 0.6});
+            polyline.addTo(map);
+            // No need to update the bounds - that happens when the mirrors dot is added below.
+        }
+    }
+    var showaftercutoff = 3; // How many mirrors without weight to use for calculating bounds
+    for (i in mapdata.mirrors) {
+        var myIcon = L.divIcon({
+            className: 'numberboxinmap' + mapdata.mirrors[i].color,
+            html: "" + mapdata.mirrors[i].nr,
+            iconSize: null,
+            iconAnchor: [8, 20]
+        });
+        var nxtmarker = new L.marker([mapdata.mirrors[i].lat, mapdata.mirrors[i].lon], {icon: myIcon});
+        nxtmarker.addTo(map);
+        if (mapdata.mirrors[i].color != "green") {
+            showaftercutoff--;
+        }
+        if (showaftercutoff > 0) {
+            latlngbounds.extend([mapdata.mirrors[i].lat, mapdata.mirrors[i].lon]);
+        }
+    }
+    latlngbounds.pad(1);
+    map.fitBounds(latlngbounds);
+
+</script>
 
 <div>
     <br/>


### PR DESCRIPTION
updated version of PR #72 
This switches the mirrorlist-template to use a map based on OSM with leaflet (javascript) instead of a image generated through Googles Maps API.
As the mirrorlist-template was the only place where GMaps was used (the mirrorstatus-template already used OSM), we can now also remove the GoogleMapsAPIKey from the config. The function for generating the URL to the image, GetMirrorMapURL(), isn't needed anymore either, and neither is the test for that function.