### PR TITLE
add the DB index to the broadcasted announce-string.

### DIFF
--- a/daemon/cluster.go
+++ b/daemon/cluster.go
@@ -11,13 +11,14 @@ import (
 	"sync"
 	"time"
 
+	. "github.com/etix/mirrorbits/config"
 	"github.com/etix/mirrorbits/database"
 	"github.com/etix/mirrorbits/mirrors"
 	"github.com/etix/mirrorbits/utils"
 )
 
 const (
-	clusterAnnounce = "HELLO"
+	clusterAnnouncePrefix = "HELLOMB"
 )
 
 type cluster struct {
@@ -33,6 +34,7 @@ type cluster struct {
 	wg            sync.WaitGroup
 	running       bool
 	StartStopLock sync.Mutex
+	announceText  string
 }
 
 type node struct {
@@ -59,6 +61,7 @@ func NewCluster(r *database.Redis) *cluster {
 		hostname = "unknown"
 	}
 	c.nodeID = fmt.Sprintf("%s-%05d", hostname, rand.Intn(32000))
+	c.announceText = clusterAnnouncePrefix + fmt.Sprintf("%d", GetConfig().RedisDB)
 	return c
 }
 
@@ -106,18 +109,18 @@ func (c *cluster) clusterLoop() {
 		case <-announceTicker.C:
 			c.announce()
 		case data := <-clusterChan:
-			if !strings.HasPrefix(data, clusterAnnounce+" ") {
+			if !strings.HasPrefix(data, c.announceText+" ") {
 				// Garbage
 				continue
 			}
-			c.refreshNodeList(data[len(clusterAnnounce)+1:], c.nodeID)
+			c.refreshNodeList(data[len(c.announceText)+1:], c.nodeID)
 		}
 	}
 }
 
 func (c *cluster) announce() {
 	r := c.redis.Get()
-	database.Publish(r, database.CLUSTER, fmt.Sprintf("%s %s", clusterAnnounce, c.nodeID))
+	database.Publish(r, database.CLUSTER, fmt.Sprintf("%s %s", c.announceText, c.nodeID))
 	r.Close()
 }
 

--- a/daemon/cluster_test.go
+++ b/daemon/cluster_test.go
@@ -47,7 +47,7 @@ func TestClusterLoop(t *testing.T) {
 
 	c := NewCluster(conn)
 
-	cmdPublish := mock.Command("PUBLISH", string(database.CLUSTER), fmt.Sprintf("%s %s", clusterAnnounce, c.nodeID)).Expect("1")
+	cmdPublish := mock.Command("PUBLISH", string(database.CLUSTER), fmt.Sprintf("%s %s", c.announceText, c.nodeID)).Expect("1")
 
 	c.Start()
 	defer c.Stop()


### PR DESCRIPTION
Add the redis-DB-index to the broadcasted announce-string.
This should fix #73
Note: This patch should be tested by someone who actually uses clustering before merging. I do not, and thus cannot verify this doesn't break it.