### PR TITLE
README: add Endless OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Mirrorbits is a geographical download redirector written in [Go](https://golang.
  * [LineageOS](http://lineageos.org) (previously CyanogenMod)
  * [Chaos Computer Club](https://media.ccc.de) (media distribution)
  * [CarbonROM](https://carbonrom.org)
+ * [Endless OS](https://endlessos.com/)
 
 Yet some things might change before the 1.0 release. If you intend to deploy Mirrorbits in a production system it is advised to notify the author first so we can help you to make any transition as seamless as possible!
 


### PR DESCRIPTION
We're now running Mirrorbits in production at
https://images-dl.endlessm.com/release/?mirrorstats