### PR TITLE
templates/mirrorstats: remove unnecessary empty <td>

### DIFF
--- a/templates/mirrorstats.html
+++ b/templates/mirrorstats.html
@@ -87,7 +87,6 @@
                 </tr>
                 <tr>
                     <td width="500" class="tooltip"><div class="bar-bytes" style="width: {{$v.PercentB}}%;"><span class="tooltiptext">{{sizeof $v.Bytes}}<br>transferred</span></div></td>
-                    <td></td>
                 </tr>{{end}}
             </table>
         </div>


### PR DESCRIPTION
This was added in f7417e4d81f1ab8907a8aa4547ee8d54cba5a3ce but it is
unnecessary. The table has three columns, and each mirror has two rows
in the table. The first row has three cells, the first and last of which
have rowspan=2. So the second row should only have one cell.