### PR TITLE
Test against latest Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: go
 sudo: required
 
+# https://docs.travis-ci.com/user/languages/go/#go-import-path
+go_import_path: github.com/etix/mirrorbits
+
 go:
-  - 1.7.6
-  - 1.8.3
-  - tip
+  - "1.10.x"
+  - "1.11.x"
+  - master
 
 os:
   - linux
 
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
See also https://github.com/etix/mirrorbits/issues/84

The `go_import_path` setting allows forks to run Travis builds otherwise it will use the wrong path and [fail like there](https://travis-ci.org/infertux/mirrorbits/jobs/451306327).