### PR TITLE
service: Support systemd notify type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.5.1
+
+### ENHANCEMENTS
+
+- Sort the mirrors by the last state date in the list command
+
+### BUGFIXES
+
+- Regression: mirrors were not able to transition between up and down states
+
 ## v0.5
 
 ### FEATURES

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -129,6 +129,12 @@ func SubCmd(name, signature, description string) *flag.FlagSet {
 	return flags
 }
 
+type ByDate []*rpc.Mirror
+
+func (d ByDate) Len() int           { return len(d) }
+func (d ByDate) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
+func (d ByDate) Less(i, j int) bool { return d[i].StateSince.Seconds > d[j].StateSince.Seconds }
+
 func (c *cli) CmdList(args ...string) error {
 	cmd := SubCmd("list", "", "Get the list of mirrors")
 	http := cmd.Bool("http", false, "Print HTTP addresses")
@@ -156,6 +162,8 @@ func (c *cli) CmdList(args ...string) error {
 	if err != nil {
 		log.Fatal("list error:", err)
 	}
+
+	sort.Sort(ByDate(list.Mirrors))
 
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)

--- a/contrib/init/systemd/mirrorbits.service.in
+++ b/contrib/init/systemd/mirrorbits.service.in
@@ -4,6 +4,7 @@ Documentation=https://github.com/etix/mirrorbits
 After=network.target
 
 [Service]
+Type=notify
 DynamicUser=yes
 LogsDirectory=mirrorbits
 RuntimeDirectory=mirrorbits

--- a/mirrors/mirrors.go
+++ b/mirrors/mirrors.go
@@ -190,7 +190,7 @@ func SetMirrorState(r *database.Redis, id int, state bool, reason string) error 
 	key := fmt.Sprintf("MIRROR_%d", id)
 
 	previousState, err := redis.Bool(conn.Do("HGET", key, "up"))
-	if err != nil {
+	if err != nil && err != redis.ErrNil {
 		return err
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,14 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "dPUClu2Gew2ddf1Y5rmgvxUUFeU=",
+			"path": "github.com/coreos/go-systemd/daemon",
+			"revision": "9002847aa1425fb6ac49077c0a630b3b67e0fbfd",
+			"revisionTime": "2018-10-31T08:50:51Z",
+			"version": "v18",
+			"versionExact": "v18"
+		},
+		{
 			"checksumSHA1": "Q7mGz8LZRezzZjrmBAL4wNJ6WrQ=",
 			"path": "github.com/etix/goftp",
 			"revision": "0c13163a1028e83f0f1cce113dddd3900e935bc7",


### PR DESCRIPTION
With the current default of Type=simple, systemd considers mirrorbits
started as soon as the mirrorbits process starts. However, neither the
RPC nor HTTP ports are bound at that point, so services that start After
mirrorbits may fail if systemd starts them immediately.

Change to Type=notify and send the READY=1 message through the notify
socket after the ports are bound but just before the HTTP server starts.
If systemd is not in use (the NOTIFY_SOCKET environment variable is not
set), then this is a no-op.

This is against the 0.5 branch (with the 0.5.1 commits) since I don't have a Go 1.11 environment handy to use the new Go module support. I can work on that, but I wanted to get an idea if this was useful or not. For me it makes our bootup process reliable since we have a service that starts after mirrorbits that exports the mirmon list to a static HTTP server path. It currently fails since the RPC port isn't bound yet.