### PR TITLE
http/context: require HTTPS based on X-Forwarded-Proto

### DIFF
--- a/http/context.go
+++ b/http/context.go
@@ -75,6 +75,13 @@ func NewContext(w http.ResponseWriter, r *http.Request, t Templates) *Context {
 		}
 	}
 
+	v, ok = r.Header["X-Forwarded-Proto"]
+	if ok {
+		if v[0] == "https" {
+			c.secureOption = WITHTLS
+		}
+	}
+
 	return c
 }
 


### PR DESCRIPTION
If mirrorbits is running behind a reverse proxy, it should honor the
X-Forwarded-Proto header to avoid downgrading the connection from HTTPS
to HTTP.