### PR TITLE
http: avoid counting very close range downloads from a same source.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ func defaultConfig() Configuration {
 		OutputMode:             "auto",
 		ListenAddress:          ":8080",
 		Gzip:                   false,
+		SameDownloadInterval:   600,
 		RedisAddress:           "127.0.0.1:6379",
 		RedisPassword:          "",
 		RedisDB:                0,
@@ -70,6 +71,7 @@ type Configuration struct {
 	OutputMode              string     `yaml:"OutputMode"`
 	ListenAddress           string     `yaml:"ListenAddress"`
 	Gzip                    bool       `yaml:"Gzip"`
+	SameDownloadInterval    int        `yaml:"SameDownloadInterval"`
 	RedisAddress            string     `yaml:"RedisAddress"`
 	RedisPassword           string     `yaml:"RedisPassword"`
 	RedisDB                 int        `yaml:"RedisDB"`

--- a/http/http.go
+++ b/http/http.go
@@ -321,7 +321,8 @@ func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Contex
 	if !ctx.IsMirrorlist() {
 		logs.LogDownload(resultRenderer.Type(), status, results, err)
 		if len(mlist) > 0 {
-			if r.Header.Get("Range") == "" {
+			timeout := GetConfig().SameDownloadInterval
+			if r.Header.Get("Range") == "" || timeout == 0 {
 				h.stats.CountDownload(mlist[0], fileInfo)
 			} else {
 				downloaderID := remoteIP+"/"+r.Header.Get("User-Agent")
@@ -335,7 +336,6 @@ func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Contex
 				tempKey := "DOWNLOADED_"+chk+"_"+urlPath
 
 				prev := ""
-				timeout := 600
 				if h.redis.IsAtLeastVersion("6.2.0") {
 					// Get and set the key in one command.
 					prev, _ = redis.String(rconn.Do("SET", tempKey, 1, "GET", "EX", timeout))

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -30,6 +30,12 @@
 ## Enable Gzip compression
 # Gzip: false
 
+## Interval in seconds between which 2 range downloads of a given file
+## from a same origin (hashed (IP, user-agent) couple) are considered
+## to be the same download. In particular, download statistics are not
+## incremented for this file.
+# SameDownloadInterval: 600
+
 ## Host and port to listen on
 # ListenAddress: :8080
 


### PR DESCRIPTION
The idea is that if a same machine downloads twice ranges of a given
file within a very short time span, it's probably 1 download (but done
in pieces).
For GIMP, we have particularly such use cases as we also serve torrent
files and use our mirrors as web seeds. So a same torrent client may end
up requesting partial bits of files.

I'm using Redis feature of temporary keys and went with 10 minutes for
expiration. Each time a new piece is requested, the timer is reset. If 2
requests are done with a longer silence frame, let's assume these are
different downloads. The logic is worth what it is, but better than just
re-counting partial downloads within seconds of intervals.

Finally I identify source clients though their (IP, user-agent), hashing
this ID for privacy and not storing non-necessary private data.

------------------------------------------

Note: we started to use Mirrorbits for GIMP a few days ago: https://download.gimp.org/pub/gimp/v2.10/gimp-2.10.32.tar.bz2?mirrorstats

I was wondering if stats were taking range downloads into consideration. Looking at the code, apparently it's not.

In GIMP, we also serve torrents file and we use our mirrors as web seeds, which means we may have torrent clients sending "GET" requests asking for a "Range". A same client may typically request several ranges to the http server, within minutes, if not seconds. Right now, each request counts as 1 download, which therefore over-estimate the download count.

Such a logic as proposed is not perfect (perfect is likely not possible here anyway), but it would get much closer to real download count.