### PR TITLE
Do not list disabled mirrors as down

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -201,7 +201,7 @@ func (c *cli) CmdList(args ...string) error {
 			}
 		}
 		if *down == true {
-			if mirror.Up == true {
+			if mirror.Up == true || mirror.Enabled == false {
 				continue
 			}
 		}


### PR DESCRIPTION
It was mentioned in issue #125 that it is confusing if mirrors that are disabled are listed as down. Therefore, `mirrorbits list -down` meets user expectations better if it does not list disabled mirrors as down. As a result, the mirror categories disabled and down do no longer intersect.