### PR TITLE
Reload logs on SIGHUP, in case the LogDir option was modified

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func main() {
 						h.Stop(1 * time.Second)
 					}
 					h.Reload()
+					logs.ReloadLogs()
 				case syscall.SIGUSR1:
 					log.Notice("SIGUSR1 Received: Re-opening logs...")
 					logs.ReloadLogs()


### PR DESCRIPTION
Here's the issue: if ever the LogDir option is modified in the
configuration file, sending SIGHUP is not enough to make the change
effective, and mirrorbits keep using the old LogDir value. In other
words: the LogDir config option is not reloaded on SIGHUP.

How to reproduce: say you have mirrorbits running, and LogDir is
commented out. It means mirrorbits doesn't log downloads under the file
`$LogDir/downloads.log`. Now, edit the configuration, uncomment LogDir,
send SIGHUP to mirrorbits, and observe that it has no effect: there is
still no file `$LogDir/downloads.log`.

I consider it a bug, even though a minor one, just a papercut.

This commit fixes it by always reloading the logs on SIGHUP, thus making
sure that, if ever LogDir was modified, the change is taken into
account.
