### PR TITLE
Draft: Add RelaxModTimeRules config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ type Configuration struct {
 	CheckInterval           int        `yaml:"CheckInterval"`
 	RepositoryScanInterval  int        `yaml:"RepositoryScanInterval"`
 	MaxLinkHeaders          int        `yaml:"MaxLinkHeaders"`
+	RelaxModTimeRules       []relaxrule `yaml:"RelaxModTimeRules"`
 	FixTimezoneOffsets      bool       `yaml:"FixTimezoneOffsets"`
 	Hashes                  hashing    `yaml:"Hashes"`
 	DisallowRedirects       bool       `yaml:"DisallowRedirects"`
@@ -109,6 +110,11 @@ type hashing struct {
 	SHA1   bool `yaml:"SHA1"`
 	SHA256 bool `yaml:"SHA256"`
 	MD5    bool `yaml:"MD5"`
+}
+
+type relaxrule struct {
+	Prefix      string `yaml:"Prefix"`
+	MaxOutdated int    `yaml:"MaxOutdated"`
 }
 
 // LoadConfig loads the configuration file if it has not yet been loaded
@@ -164,6 +170,17 @@ func ReloadConfig() error {
 	}
 	if c.RepositoryScanInterval < 0 {
 		c.RepositoryScanInterval = 0
+	}
+	for _, r := range c.RelaxModTimeRules {
+		if len(r.Prefix) == 0 {
+			return fmt.Errorf("RelaxModTimeRules.Prefix must be set")
+		}
+		if r.Prefix[0] != '/' {
+			return fmt.Errorf("RelaxModTimeRules.Prefix must start with a /")
+		}
+		if r.MaxOutdated <= 0 {
+			return fmt.Errorf("RelaxModTimeRules.MaxOutdated must be > 0")
+		}
 	}
 
 	if config != nil &&

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -103,6 +103,16 @@
 ## Disable a mirror if an active file is missing (HTTP 404)
 # DisableOnMissingFile: false
 
+## Relax the modtime check for some files.
+## With this setting, files are allowed to be outdated on the mirrors, for at
+## most MaxOutdated minutes. The filesize check is also disabled for those
+## files. Use-case: for a Debian-like distribution, the metadata (ie. the
+## directory /dists) are updated in-place, so we must give time for mirrors
+## to sync, and then for mirrorbits to be aware of the changes.
+# RelaxModTimeRules:
+#     - Prefix: /dists/
+#       MaxOutdated: 540
+
 ## Adjust the weight/range of the geographic distribution
 # WeightDistributionRange: 1.5
 


### PR DESCRIPTION
With this setting, files are allowed to be outdated on the mirrors, for at most MaxOutdated minutes. The filesize check is also disabled for those files.

Use-case: for a Debian-like distribution, the metadata (ie.  the directory /dists) are updated in-place, so we must give time for mirrors to sync, and then for mirrorbits to be aware of the changes.

Otherwise, as soon as the source is updated and scanned, Mirrorbits will go in fallback mode for all the files under /dists, since at this point, either mirrors didn't sync yet, either they did but Mirrorbits is not aware of it yet (as the interval to scan mirrors is higher than the interval to scan the source).

Cf. https://github.com/etix/mirrorbits/issues/85 for more details.