### PR TITLE
Prevent yaml.Marshal from wrapping long lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/etix/mirrorbits/rpc"
 	"github.com/op/go-logging"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -31,6 +32,10 @@ var (
 )
 
 func main() {
+	// Prevent yaml.Marshal from wrapping long lines, cf:
+	// https://pkg.go.dev/gopkg.in/yaml.v2#FutureLineWrap
+	yaml.FutureLineWrap()
+
 	core.Parseflags()
 
 	if core.CpuProfile != "" {


### PR DESCRIPTION
Line wrapping after 80 characters was the default in yaml.v2. No line wrapping is the default for yaml.v3. The helper FutureLineWrap() is meant to help users do the transition to the new behavior.

For mirrorbits, line wrapping manifests itselfs for the `show` and `edit` commands. It's an issue, in the sense that it makes it difficult for scripts to interact with those commands (as long values might spread on several lines, so a simple grep won't do).

Hence this commit disables line wrapping.

Closes: #153