### PR TITLE
mirrorlist: Better display for files that were not scanned yet

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -336,6 +336,7 @@ func (h *HTTP) LoadTemplates(name string) (t *template.Template, err error) {
 		"hostname":  utils.Hostname,
 		"concaturl": utils.ConcatURL,
 		"dateutc":   utils.FormattedDateUTC,
+		"iszero":    utils.IsZero,
 	})
 	t, err = t.ParseFiles(
 		filepath.Clean(GetConfig().Templates+"/base.html"),

--- a/templates/mirrorlist.html
+++ b/templates/mirrorlist.html
@@ -112,7 +112,13 @@
 
         <div style="flex-basis: 325px; flex-grow: 1; margin: 8px;">
             <h3>File</h3>
-            <div>The file <b>{{.FileInfo.Path}}</b> has a size of {{sizeof .FileInfo.Size}} ({{.FileInfo.Size}} bytes) and was last modified on {{dateutc .FileInfo.ModTime}}.</div>
+            <div>
+            {{if not (iszero .FileInfo.ModTime)}}
+                The file <b>{{.FileInfo.Path}}</b> has a size of {{sizeof .FileInfo.Size}} ({{.FileInfo.Size}} bytes) and was last modified on {{dateutc .FileInfo.ModTime}}.
+            {{else}}
+                The file <b>{{.FileInfo.Path}}</b> has not been scanned yet, size and modification time are unknown.
+            {{end}}
+            </div>
             <div>
                 <br/>Known hashes:
                 <table class="alt">

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -165,6 +165,11 @@ func FormattedDateUTC(t time.Time) string {
 	return t.UTC().Format(time.RFC1123)
 }
 
+// IsZero returns whether the date represents the zero time instant
+func IsZero(t time.Time) bool {
+	return t.IsZero()
+}
+
 // TimeKeyCoverage returns a slice of strings covering the date range
 // used in the redis backend.
 func TimeKeyCoverage(start, end time.Time) (dates []string) {


### PR DESCRIPTION
As reported in https://github.com/etix/mirrorbits/issues/114, the mirrorlist page shows information that is rather confusing when a file is 1) present on the local repo but 2) has not been scanned yet.

This commit aims (and hopefully succeeds) at improving the situation.