### PR TITLE
Switch to gopkg.in/yaml.v3

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/etix/mirrorbits/core"
 	"github.com/op/go-logging"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	google.golang.org/grpc v1.23.1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/tylerb/graceful.v1 v1.2.15
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.1
 	vitess.io/vitess v2.1.1+incompatible // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ gopkg.in/tylerb/graceful.v1 v1.2.15 h1:1JmOyhKqAyX3BgTXMI84LwT6FOJ4tP2N9e2kwTCM0
 gopkg.in/tylerb/graceful.v1 v1.2.15/go.mod h1:yBhekWvR20ACXVObSSdD3u6S9DeSylanL2PAbAC/uJ8=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 vitess.io/vitess v2.1.1+incompatible h1:nuuGHiWYWpudD3gOCLeGzol2EJ25e/u5Wer2wV1O130=

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (


### PR DESCRIPTION
The main reason to switch (apart from keeping dependencies up-to-date) is the default behaviour for line wrapping. In yaml.v2, the default was line wrapping after 80 characters. In yaml.v3, no line wrapping by default.

For mirrorbits, line wrapping manifests itself in the `show` and `edit` commands. It's an issue, in the sense that it makes it difficult for scripts to interact with those commands, since long values might spread over several lines. For example, parsing the output of `mirrorbits show` with `grep` is error prone because of line wrapping.

This commit bumps the build depencency gopkg.in/yaml from v2 to v3, thus disabling line wrapping in yaml output.

Closes: #153