### PR TITLE
contrib: Update bash completion for commands reload, upgrade and version

### DIFF
--- a/contrib/completions/mirrorbits.bash
+++ b/contrib/completions/mirrorbits.bash
@@ -132,9 +132,7 @@ _mirrorbits() {
                 COMPREPLY=( $( compgen -W '-help -rehash' -- "$cur" ) )
                 ;;
             reload|upgrade|version)
-                # XXX Not supported yet
-                #COMPREPLY=( $( compgen -W '-help' -- "$cur" ) )
-                COMPREPLY=()
+                COMPREPLY=( $( compgen -W '-help' -- "$cur" ) )
                 ;;
             remove)
                 case $cur in


### PR DESCRIPTION
The -help flag for those commands was added in
1fe530495bac08e34e0fdae0aa44e54e511f62fb