### PR TITLE
Minor fixes and improvements in mirrors/cache_test.go

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -443,11 +443,9 @@ func (h *HTTP) checksumHandler(w http.ResponseWriter, r *http.Request, ctx *Cont
 		return
 	}
 
+	// Get details about the requested file
 	fileInfo, err := h.cache.GetFileInfo(urlPath)
-	if err == redis.ErrNil {
-		http.NotFound(w, r)
-		return
-	} else if err != nil {
+	if err != nil {
 		log.Errorf("Error while fetching Fileinfo: %s", err.Error())
 		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
 		return

--- a/mirrors/cache_test.go
+++ b/mirrors/cache_test.go
@@ -323,12 +323,12 @@ func TestCache_fetchFileInfoMirror(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFileinfomirror := mock.Command("HMGET", "FILEINFO_1_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").ExpectMap(map[string]string{
-		"size":    strconv.FormatInt(testfile.Size, 10),
-		"modTime": testfile.ModTime.String(),
-		"sha1":    testfile.Sha1,
-		"sha256":  testfile.Sha256,
-		"md5":     testfile.Md5,
+	cmdGetFileinfomirror := mock.Command("HMGET", "FILEINFO_1_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+		[]byte(strconv.FormatInt(testfile.Size, 10)),
+		[]byte(testfile.ModTime.String()),
+		[]byte(testfile.Sha1),
+		[]byte(testfile.Sha256),
+		[]byte(testfile.Md5),
 	})
 
 	_, err = c.fetchFileInfoMirror(1, testfile.Path)
@@ -337,7 +337,7 @@ func TestCache_fetchFileInfoMirror(t *testing.T) {
 	}
 
 	if mock.Stats(cmdGetFileinfomirror) < 1 {
-		t.Fatalf("HGETALL not executed")
+		t.Fatalf("HMGET not executed")
 	}
 
 	_, ok := c.fimCache.Get("1|" + testfile.Path)
@@ -420,20 +420,20 @@ func TestCache_GetMirrors(t *testing.T) {
 		"longitude": "0.1275",
 	})
 
-	cmdGetFileinfomirrorM1 := mock.Command("HMGET", "FILEINFO_1_"+filename, "size", "modTime", "sha1", "sha256", "md5").ExpectMap(map[string]string{
-		"size":    "44000",
-		"modTime": "",
-		"sha1":    "",
-		"sha256":  "",
-		"md5":     "",
+	cmdGetFileinfomirrorM1 := mock.Command("HMGET", "FILEINFO_1_"+filename, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+		[]byte("44000"),
+		[]byte(""),
+		[]byte(""),
+		[]byte(""),
+		[]byte(""),
 	})
 
-	cmdGetFileinfomirrorM2 := mock.Command("HMGET", "FILEINFO_2_"+filename, "size", "modTime", "sha1", "sha256", "md5").ExpectMap(map[string]string{
-		"size":    "44000",
-		"modTime": "",
-		"sha1":    "",
-		"sha256":  "",
-		"md5":     "",
+	cmdGetFileinfomirrorM2 := mock.Command("HMGET", "FILEINFO_2_"+filename, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+		[]byte("44000"),
+		[]byte(""),
+		[]byte(""),
+		[]byte(""),
+		[]byte(""),
 	})
 
 	mirrors, err := c.GetMirrors(filename, clientInfo)
@@ -442,7 +442,7 @@ func TestCache_GetMirrors(t *testing.T) {
 	}
 
 	if mock.Stats(cmdGetFilemirrors) < 1 {
-		t.Fatalf("cmd_get_filemirrors not called")
+		t.Fatalf("cmdGetFilemirrors not called")
 	}
 	if mock.Stats(cmdGetMirrorM1) < 1 {
 		t.Fatalf("cmdGetMirrorM1 not called")
@@ -451,10 +451,10 @@ func TestCache_GetMirrors(t *testing.T) {
 		t.Fatalf("cmdGetMirrorM2 not called")
 	}
 	if mock.Stats(cmdGetFileinfomirrorM1) < 1 {
-		t.Fatalf("cmd_get_fileinfomirror_m1 not called")
+		t.Fatalf("cmdGetFileinfomirrorM1 not called")
 	}
 	if mock.Stats(cmdGetFileinfomirrorM2) < 1 {
-		t.Fatalf("cmd_get_fileinfomirror_m2 not called")
+		t.Fatalf("cmdGetFileinfomirrorM2 not called")
 	}
 
 	if len(mirrors) != 2 {

--- a/mirrors/cache_test.go
+++ b/mirrors/cache_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/etix/mirrorbits/filesystem"
 	"github.com/etix/mirrorbits/network"
 	. "github.com/etix/mirrorbits/testing"
-	"github.com/gomodule/redigo/redis"
 	_ "github.com/rafaeljusto/redigomock"
 )
 
@@ -174,10 +173,11 @@ func TestCache_GetFileInfo(t *testing.T) {
 	}
 
 	_, err = c.GetFileInfo(testfile.Path)
-	if err == redis.ErrNil {
-		t.Fatalf("Cache not used, request expected to be done once")
-	} else if err != nil {
+	if err != nil {
 		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+	if mock.Stats(cmdGetFileinfo) > 1 {
+		t.Fatalf("Cache not used, request expected to be done once")
 	}
 }
 


### PR DESCRIPTION
This MR puts some work in `mirrors/cache_test.go`, there are minor fixes, and two extra tests.

The main outcome is that we now clarify that the function `GetFileInfo` does NOT return `Redis.ErrNil` when the file requested is not found. It doesn't return any error at all, instead it returns a struct with only the field `Path` populated. Note that it was already pretty clear by just looking at the implementation of `GetFileInfo`, but now it's also backed with unit tests.

Based on that, the last commit of this MR drops a useless (and confusing) check for `Redis.ErrNil`.

This work is in preparation of another MR that reworks the moment when `GetFileInfo` is called. It was important to clarify the exact behavior of `GetFileInfo` before being able to to that.