### PR TITLE
Add support for If-Modified-Since (RFC-7232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Mirrorbits is a geographical download redirector written in [Go](https://golang.
 * Seamless binary upgrade (aka zero downtime upgrade)
 * [Mirmon](http://www.staff.science.uu.nl/~penni101/mirmon/) support
 * Full **IPv6** support
+* If-Modified-Since (RFC-7232) support
 * more...
 
 ## Is it production ready?

--- a/http/http.go
+++ b/http/http.go
@@ -264,6 +264,7 @@ func writeNotModified(w http.ResponseWriter) {
 	h := w.Header()
 	delete(h, "Content-Type")
 	delete(h, "Content-Length")
+	delete(h, "Content-Encoding")
 	if h.Get("Etag") != "" {
 		delete(h, "Last-Modified")
 	}

--- a/http/http.go
+++ b/http/http.go
@@ -231,7 +231,13 @@ func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Contex
 		return
 	}
 
-	fileInfo := filesystem.NewFileInfo(urlPath)
+	// Get details about the requested file
+	fileInfo, err := h.cache.GetFileInfo(urlPath)
+	if err != nil {
+		log.Errorf("Error while fetching Fileinfo: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	remoteIP := network.ExtractRemoteIP(r.Header.Get("X-Forwarded-For"))
 	if len(remoteIP) == 0 {

--- a/http/http.go
+++ b/http/http.go
@@ -42,6 +42,14 @@ const (
 	condFalse
 )
 
+// TimeFormat is the time format to use when generating times in HTTP
+// headers. It is like [time.RFC1123] but hard-codes GMT as the time
+// zone. The time being formatted must be in UTC for Format to
+// generate the correct format.
+//
+// For parsing this time format, see [ParseTime].
+const TimeFormat = "Mon, 02 Jan 2006 15:04:05 GMT"
+
 var unixEpochTime = time.Unix(0, 0)
 
 var (
@@ -234,6 +242,12 @@ func isZeroTime(t time.Time) bool {
 	return t.IsZero() || t.Equal(unixEpochTime)
 }
 
+func setLastModified(w http.ResponseWriter, modtime time.Time) {
+        if !isZeroTime(modtime) {
+                w.Header().Set("Last-Modified", modtime.UTC().Format(TimeFormat))
+        }
+}
+
 func checkIfModifiedSince(r *http.Request, modtime time.Time) condResult {
 	if r.Method != "GET" && r.Method != "HEAD" {
 		return condNone
@@ -294,6 +308,7 @@ func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Contex
 	}
 
 	if checkIfModifiedSince(r, fileInfo.ModTime) == condFalse {
+		setLastModified(w, fileInfo.ModTime)
 		writeNotModified(w)
 		return
 	}

--- a/http/http.go
+++ b/http/http.go
@@ -237,6 +237,36 @@ func (h *HTTP) requestDispatcher(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// The functions below were picked from go/src/net/http/fs.go
+//
+// Copyright 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// 
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 // isZeroTime reports whether t is obviously unspecified (either zero or Unix()=0).
 func isZeroTime(t time.Time) bool {
 	return t.IsZero() || t.Equal(unixEpochTime)
@@ -284,6 +314,8 @@ func writeNotModified(w http.ResponseWriter) {
 	}
 	w.WriteHeader(http.StatusNotModified)
 }
+
+// End of functions from go/src/net/http/fs.go
 
 func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Context) {
 	//XXX it would be safer to recover in case of panic

--- a/http/selection.go
+++ b/http/selection.go
@@ -29,12 +29,6 @@ type DefaultEngine struct{}
 
 // Selection returns an ordered list of selected mirror, a list of rejected mirrors and and an error code
 func (h DefaultEngine) Selection(ctx *Context, cache *mirrors.Cache, fileInfo *filesystem.FileInfo, clientInfo network.GeoIPRecord) (mlist mirrors.Mirrors, excluded mirrors.Mirrors, err error) {
-	// Get details about the requested file
-	*fileInfo, err = cache.GetFileInfo(fileInfo.Path)
-	if err != nil {
-		return
-	}
-
 	// Prepare and return the list of all potential mirrors
 	mlist, err = cache.GetMirrors(fileInfo.Path, clientInfo)
 	if err != nil {


### PR DESCRIPTION
Please see https://github.com/etix/mirrorbits/pull/168 for prior work (ideally merged before this one).

With this MR, we now enable support for the `If-Modified-Since` client header (RFC-7232). A client might request a file only if it modified since a certain date. If it was not, mirrorbits will now return `304` "Not Modified".

This is based on initial work by @ott at https://github.com/etix/mirrorbits/pull/131. This will close https://github.com/etix/mirrorbits/issues/115.

It might make sense to squash all those commits, but I wanted to preserve @ott authorship, and for review it's always easier to have small commits. Feel free to squash during the merge if you prefer.

## Use-case

Clients that use this feature: `apt` for Debian-based Linux distributions. The command `apt update` downloads metadata from a package repository, and keeps a local copy of it. Requests include `If-Modified-Since` with the date of the metadata, so that if user runs `apt update` a bunch of times in a row, only the first request downloads files, and subsequent requests won't download anything if ever the server replies with 304.

In practice, for Kali Linux we now use mirrorbits for the package repository.

Before this MR, running `apt update` while we already have an up-to-date local copy of the metadata would results in two round trips: 1 round-trip to the redirector that serves the redirection, and then 1 round-trip to the mirror that serves a `304` (as nginx seems to do that by default). Example:

```
┌──(root㉿carbon)-[/work]
└─# apt -y -q -o Debug::Acquire::http=true update
GET /kali/dists/kali-rolling/InRelease HTTP/1.1
Host: http.kali.org
Cache-Control: max-age=0
Accept: text/*
If-Modified-Since: Fri, 08 Mar 2024 12:05:52 GMT
User-Agent: Debian APT-HTTP/1.3 (2.7.10)


Answer for: http://http.kali.org/kali/dists/kali-rolling/InRelease
HTTP/1.1 302 Found
Server: nginx
Date: Fri, 08 Mar 2024 14:28:41 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Cache-Control: private, no-cache
Link: <http://kali.download/kali/dists/kali-rolling/InRelease>; rel=duplicate; pri=1; geo=ae
Link: <http://mirror.aktkn.sg/kali/dists/kali-rolling/InRelease>; rel=duplicate; pri=2; geo=sg
Location: http://mirror.kku.ac.th/kali/dists/kali-rolling/InRelease

GET /kali/dists/kali-rolling/InRelease HTTP/1.1
Host: mirror.kku.ac.th
Cache-Control: max-age=0
Accept: text/*
If-Modified-Since: Fri, 08 Mar 2024 12:05:52 GMT
User-Agent: Debian APT-HTTP/1.3 (2.7.10)


Answer for: http://mirror.kku.ac.th/kali/dists/kali-rolling/InRelease
HTTP/1.1 304 Not Modified
Server: nginx
Date: Fri, 08 Mar 2024 14:28:41 GMT
Last-Modified: Fri, 08 Mar 2024 12:05:52 GMT
Connection: keep-alive
ETag: "65eaff20-a21d"
```

After this MR, it's now mirrorbits that serve the `304`, thus saving a round trip:

```
┌──(root㉿carbon)-[/work]
└─# apt -y -q -o Debug::Acquire::http=true update
GET /kali/dists/kali-rolling/InRelease HTTP/1.1
Host: http.kali.org
Cache-Control: max-age=0
Accept: text/*
If-Modified-Since: Mon, 11 Mar 2024 00:08:32 GMT
User-Agent: Debian APT-HTTP/1.3 (2.7.10)


Answer for: http://http.kali.org/kali/dists/kali-rolling/InRelease
HTTP/1.1 304 Not Modified
Server: nginx
Date: Mon, 11 Mar 2024 06:18:55 GMT
Connection: keep-alive
Last-Modified: Mon, 11 Mar 2024 00:08:32 GMT
```