### PR TITLE
http, logs: only count GET requests as downloads.

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -431,8 +431,8 @@ func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Contex
 	}
 
 	if !ctx.IsMirrorlist() {
-		logs.LogDownload(resultRenderer.Type(), status, results, err)
-		if len(mlist) > 0 {
+		logs.LogDownload(resultRenderer.Type(), r.Method, status, results, err)
+		if len(mlist) > 0 && r.Method == "GET" {
 			timeout := GetConfig().SameDownloadInterval
 			if r.Header.Get("Range") == "" || timeout == 0 {
 				h.stats.CountDownload(mlist[0], fileInfo)

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -149,7 +149,7 @@ func ReloadDownloadLogs() {
 }
 
 // LogDownload writes a download result to the logs
-func LogDownload(typ string, statuscode int, p *mirrors.Results, err error) {
+func LogDownload(typ string, method string, statuscode int, p *mirrors.Results, err error) {
 	dlogger.RLock()
 	defer dlogger.RUnlock()
 
@@ -177,8 +177,8 @@ func LogDownload(typ string, statuscode int, p *mirrors.Results, err error) {
 			sameASNum = "same"
 		}
 
-		dlogger.l.Printf("%s %d \"%s\" ip:%s mirror:%s%s %sasn:%d distance:%skm countries:%s",
-			typ, statuscode, p.FileInfo.Path, p.IP, m.Name, fallback, sameASNum, m.Asnum, distance, countries)
+		dlogger.l.Printf("%s %d \"%s\" method:%s ip:%s mirror:%s%s %sasn:%d distance:%skm countries:%s",
+			typ, statuscode, p.FileInfo.Path, method, p.IP, m.Name, fallback, sameASNum, m.Asnum, distance, countries)
 	} else if statuscode == 404 && p != nil {
 		dlogger.l.Printf("%s 404 \"%s\" ip:%s", typ, p.FileInfo.Path, p.IP)
 	} else if statuscode == 500 && p != nil {

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -241,18 +241,18 @@ func TestLogDownload(t *testing.T) {
 	dlogger.Close()
 
 	// The next line isn't supposed to crash.
-	LogDownload("", 500, nil, nil)
+	LogDownload("", "GET", 500, nil, nil)
 
 	setDownloadLogWriter(&buf, true)
 
 	buf.Reset()
 
 	// The next few lines arent't supposed to crash.
-	LogDownload("", 200, nil, nil)
-	LogDownload("", 302, nil, nil)
-	LogDownload("", 404, nil, nil)
-	LogDownload("", 500, nil, nil)
-	LogDownload("", 501, nil, nil)
+	LogDownload("", "GET", 200, nil, nil)
+	LogDownload("", "GET", 302, nil, nil)
+	LogDownload("", "GET", 404, nil, nil)
+	LogDownload("", "GET", 500, nil, nil)
+	LogDownload("", "GET", 501, nil, nil)
 
 	if c := strings.Count(buf.String(), "\n"); c != 5 {
 		t.Fatalf("Invalid number of lines, got %d, expected 5", c)


### PR DESCRIPTION
Other request methods such as POST or HEAD or anything else than GET should not be counted as a new download.

-----------------

GNOME admins updated our MirrorBits instance for GIMP now that #128 is merged, but I was disappointed to still see a lot of downloads (too many that I would believe, i.e. 2.6 million downloads a day!). I looked closer at MirrorBits code and realized it is counting as download any request. In particular, I am guessing that `HEAD` may be quite a common request run by download accelerators or torrent clients on webseeds… well I am mostly guessing that this may be another source of false positives which may explain our huge stats.

In any case, whether it's a reason or not for our over-high stats, I think it does make sense that only GET requests should be counted as downloads, right?

Note that it would still log all requests (adding an additional "method:GET" or "method:HEAD" for instance in the log file), but only the GET requests would now increase the download stats.