### PR TITLE
mirrorbits-del-stats: allow passing the host to redis-cli

### DIFF
--- a/contrib/mirrorbits-del-stats
+++ b/contrib/mirrorbits-del-stats
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-USAGE="Usage: $(basename $0) [-f] <period>:<retention>... [REDIS_CLI_ARGS...]
+USAGE="Usage: $(basename $0) [-f] <period>:<retention>... [--] [REDIS_CLI_ARGS...]
 
 Delete old Mirrorbits stats.
 
@@ -31,6 +31,7 @@ FORCE=0
 
 while [ $# -gt 0 ]; do
     case $1 in
+        --) shift; break ;;
         -f|--force) FORCE=1 ;;
         -h|--help) echo "$USAGE"; exit 0 ;;
 	-*) break ;;


### PR DESCRIPTION
Passing the host to redis-cli is only possible via the "-h" switch, which clashes with the "-h" interpreted as "--help" in the script.

Make "--" stop the argument parsing, so "-h" can be forwarded to redis-cli:

mirrorbits-del-stats daily:30 monthly:12 -- -h redis