### PR TITLE
cli: Try harder to find a suitable text editor

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -563,9 +563,17 @@ func (c *cli) CmdEdit(args ...string) error {
 
 	// Find the editor to use
 	editor := os.Getenv("EDITOR")
-
 	if editor == "" {
-		log.Fatal("Environment variable $EDITOR not set")
+		for _, p := range []string{"editor", "vi", "emacs", "nano"} {
+			_, err := exec.LookPath(p)
+			if err == nil {
+				editor = p
+				break
+			}
+		}
+		if editor == "" {
+			log.Fatal("No text editor found, please set the EDITOR environment variable")
+		}
 	}
 
 	id, _ := c.matchMirror(cmd.Arg(0))


### PR DESCRIPTION
Currently the command `mirrorbits edit` errors out when the EDITOR environment variable is not set:

```
$ mirrorbits edit mirror.example.com
2024/12/17 14:07:58 Environment variable $EDITOR not set
```

It's not difficult to do better, we can check for the most common text editors. `editor` is checked first, it should be a symlink to the prefered editor on Debian systems (configured by user).

Note that this code was not invented here, it's taken verbatim from incus source code, with thanks.