### PR TITLE
Allow outdated files on mirrors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type Configuration struct {
 	DisallowRedirects       bool       `yaml:"DisallowRedirects"`
 	WeightDistributionRange float32    `yaml:"WeightDistributionRange"`
 	DisableOnMissingFile    bool       `yaml:"DisableOnMissingFile"`
+	AllowOutdatedFiles      []OutdatedFilesConfig `yaml:"AllowOutdatedFiles"`
 	Fallbacks               []fallback `yaml:"Fallbacks"`
 
 	RedisSentinelMasterName string      `yaml:"RedisSentinelMasterName"`
@@ -113,6 +114,11 @@ type hashing struct {
 	SHA1   bool `yaml:"SHA1"`
 	SHA256 bool `yaml:"SHA256"`
 	MD5    bool `yaml:"MD5"`
+}
+
+type OutdatedFilesConfig struct {
+	Prefix  string `yaml:"Prefix"`
+	Minutes int    `yaml:"Minutes"`
 }
 
 // LoadConfig loads the configuration file if it has not yet been loaded
@@ -168,6 +174,14 @@ func ReloadConfig() error {
 	}
 	if c.RepositoryScanInterval < 0 {
 		c.RepositoryScanInterval = 0
+	}
+	for _, rule := range c.AllowOutdatedFiles {
+		if len(rule.Prefix) > 0 && rule.Prefix[0] != '/' {
+			return fmt.Errorf("AllowOutdatedFiles.Prefix must start with '/'")
+		}
+		if rule.Minutes < 0 {
+			return fmt.Errorf("AllowOutdatedFiles.Minutes must be >= 0")
+		}
 	}
 
 	if config != nil &&

--- a/http/selection.go
+++ b/http/selection.go
@@ -242,10 +242,12 @@ func Filter(mlist mirrors.Mirrors, secureOption SecureOption, fileInfo *filesyst
 			if !m.FileInfo.ModTime.IsZero() {
 				mModTime := m.FileInfo.ModTime
 				if GetConfig().FixTimezoneOffsets {
-					mModTime = mModTime.Add(time.Duration(m.TZOffset) * time.Millisecond)
+					offset := time.Duration(m.TZOffset) * time.Millisecond
+					mModTime = mModTime.Add(offset)
 				}
-				mModTime = mModTime.Truncate(m.LastSuccessfulSyncPrecision.Duration())
-				lModTime := fileInfo.ModTime.Truncate(m.LastSuccessfulSyncPrecision.Duration())
+				precision := m.LastSuccessfulSyncPrecision.Duration()
+				mModTime = mModTime.Truncate(precision)
+				lModTime := fileInfo.ModTime.Truncate(precision)
 				if !mModTime.Equal(lModTime) {
 					m.ExcludeReason = fmt.Sprintf("Mod time mismatch (diff: %s)", lModTime.Sub(mModTime))
 					goto discard

--- a/http/selection_test.go
+++ b/http/selection_test.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -14,19 +15,26 @@ import (
 	"github.com/etix/mirrorbits/mirrors"
 )
 
-func TestFilter(t *testing.T) {
-	// The configuration must have been loaded
+var noFileInfo *filesystem.FileInfo
+var noClientInfo network.GeoIPRecord
+
+func TestMain(m *testing.M) {
+	noFileInfo = nil
+	noClientInfo = network.GeoIPRecord{}
 	SetConfiguration(&Configuration{
 		FixTimezoneOffsets: false,
 	})
+	os.Exit(m.Run())
+}
 
+func TestFilter(t *testing.T) {
 	// Test that a mirror that is disabled is rejected
 
 	m1 := mirrors.Mirror{
 		HttpURL: "http://m1.mirror",
 	}
 	mlist := mirrors.Mirrors{m1}
-	a, x, _, _ := Filter(mlist, UNDEFINED, nil, network.GeoIPRecord{})
+	a, x, _, _ := Filter(mlist, UNDEFINED, noFileInfo, noClientInfo)
 	if len(a) != 0 || len(x) != 1 {
 		t.Fatalf("There should be 0 mirror accepted and 1 mirror excluded")
 	}
@@ -108,7 +116,7 @@ func TestFilter(t *testing.T) {
 		}
 		mlist := mirrors.Mirrors{m1}
 		t.Run(name, func(t *testing.T) {
-			a, x, _, _ := Filter(mlist, test.secureOption, nil, network.GeoIPRecord{})
+			a, x, _, _ := Filter(mlist, test.secureOption, noFileInfo, noClientInfo)
 			if len(a) != 0 || len(x) != 1 {
 				t.Fatalf("There should be 0 mirror accepted and 1 mirror excluded")
 			}
@@ -168,7 +176,7 @@ func TestFilter(t *testing.T) {
 		}
 		mlist := mirrors.Mirrors{m1}
 		t.Run(name, func(t *testing.T) {
-			a, x, _, _ := Filter(mlist, WITHTLS, testfile, network.GeoIPRecord{})
+			a, x, _, _ := Filter(mlist, WITHTLS, testfile, noClientInfo)
 			if len(a) != 0 || len(x) != 1 {
 				t.Fatalf("There should be 0 mirror accepted and 1 mirror excluded")
 			}
@@ -376,7 +384,7 @@ func TestFilterAllowOutdatedFiles(t *testing.T) {
 			mlist := mirrors.Mirrors{m1}
 
 			t.Run(name, func(t *testing.T) {
-				a, x, _, _ := Filter(mlist, WITHTLS, testfile, network.GeoIPRecord{})
+				a, x, _, _ := Filter(mlist, WITHTLS, testfile, noClientInfo)
 				testExcludeReason := test.excludeReason[idx]
 				if testExcludeReason != "" {
 					if len(a) != 0 || len(x) != 1 {
@@ -456,7 +464,7 @@ func TestFilterFixTimezoneOffsets(t *testing.T) {
 			mlist := mirrors.Mirrors{m1}
 
 			t.Run(name, func(t *testing.T) {
-				a, x, _, _ := Filter(mlist, WITHTLS, fileRequested, network.GeoIPRecord{})
+				a, x, _, _ := Filter(mlist, WITHTLS, fileRequested, noClientInfo)
 				testExcludeReason := test.excludeReason[idx]
 				if testExcludeReason != "" {
 					if len(a) != 0 || len(x) != 1 {

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -114,6 +114,16 @@
 ## Disable a mirror if an active file is missing (HTTP 404)
 # DisableOnMissingFile: false
 
+## Allow some files to be outdated on the mirrors.
+## When the requested file matches any of the rules below, the file is allowed
+## to be outdated at most Minutes minutes, and the file size is not checked.
+## This might be desirable if the repository contains some files that are
+## updated in-place, to prevent Mirrorbits from redirecting all the traffic to
+## fallback mirrors for those files when they are modified.
+# AllowOutdatedFiles:
+#     - Prefix: /dists/
+#       Minutes: 540
+
 ## Adjust the weight/range of the geographic distribution
 # WeightDistributionRange: 1.5
 


### PR DESCRIPTION
This PR applies after https://github.com/etix/mirrorbits/pull/186, therefore it will need to be rebased after/if https://github.com/etix/mirrorbits/pull/186 gets merged. Only the 6 last commits really belong to this PR.

No need to review it before https://github.com/etix/mirrorbits/pull/186 gets sorted out.

This PR replaces https://github.com/etix/mirrorbits/pull/147

It fixes https://github.com/etix/mirrorbits/issues/85 for Debian-like distributions. The setting proposed here is kind of minimal, but it should be easy to extend it in the future (ie. match files with regex rather than prefix), if ever a needs arise.

----

The new setting `AllowOutdatedFiles` allows user to define which files are allowed to be outdated on the mirrors, and for how long.

The user defines a list of rules, each rule is of the form:
- `Prefix`: matched against the beginning of the path of the requested file
- `Minute`: if Prefix matches, how long the file is allowed to be oudated

`AllowOutdatedFiles` is a list of rules, they are checked in order, and the first rule that matches is selected.

Note that, when a rule matches, the filesize check is also disabled for this file. As it wouldn't make much sense if we allowed a file to be outdated, but didn't allow it to be of a different size.

Now, here's the use-case for this setting.

For a Debian-like distribution, the directory `/dists` (aka. the metadata of the repository) contains a lot of files that are updated in-place.  Each time the repository is updated, and immediately after mirrorbits rescans the local repo, mirrorbits redirects all the traffic for those files to the fallback mirror, since they have a new modtime, a new size, and mirrorbits doesn't know yet any mirror with those new files. It's only after 1) mirrors sync with the origin repository and 2) mirrorbits scans the updated mirrors, that it can redirect traffic to mirrors again.

For more details in a real-life setup: Kali Linux is a rolling distro, the repository is updated every 6 hours, and mirrors are scanned every hour.  In effect, it means that every 6 hours, mirrorbits redirects most of the metadata traffic to the fallback mirrors, then it takes around 1 to 2 hours before all the mirrors are scanned and traffic flows back to normal. Then again, 4 times a day.

To prevent that, Kali uses the following setting:

```
AllowOutdatedFiles:
    - Prefix: /dists/
      Minutes: 540
```



