### PR TITLE
mirrorbits-geoupdate-all: Document a bug with this script

### DIFF
--- a/contrib/mirrorbits-geoupdate-all
+++ b/contrib/mirrorbits-geoupdate-all
@@ -25,6 +25,11 @@ For example, the command:
     mirrorbits-geoupdate-all -f -- -p 3391
 
 updates all the mirrors for the mirrorbits instance listening on port 3391.
+
+BUGS: This script assumes that calling 'mirrorbits geoupdate \$mirror' twice
+in a row returns the same result, but this is not always true. For some
+mirrors, the hostname returns more than one address, and each address might
+have a different geolocation, maybe even different a ASN.
 "
 
 FORCE=0


### PR DESCRIPTION
The only way to fix this is to improve the 'mirrorbits geoupdate' command so that it can have a "automatic but conservative" mode.

Ie. the `geoupdate` command should have a way to prompt users only for ASN, Country or Continent change, but apply Latitude and Longitude changes automatically without asking.

Except that it's not clear that every user want that, maybe some would like ASN changes to be applied automatically?

In the meantime, document the issue.