### PR TITLE
cli: Fix incorrect comment

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -341,7 +341,7 @@ func (c *cli) CmdAdd(args ...string) error {
 		fmt.Fprintf(os.Stderr, "The HTTP URL has an invalid scheme\n")
 		os.Exit(-1)
 	} else {
-		// No scheme, that's a "relative URLs", and we do accept it.
+		// No scheme, yes we do accept it.
 		// Note that the documentation of net/url mentions that parsing
 		// such URL is "invalid but may not necessarily return an error",
 		// so let's add a scheme before we parse it.


### PR DESCRIPTION
A URL without a scheme is NOT a relative URL.

Unfortunately I used this wrong term in a bunch of commit messages before. Sorry for the confusion.

Fortunately I didn't use the term in any place of the code, except this very comment, so fix it now.

For the avid reader: Wikipedia tells us that we can use the term "Protocol-relative URLs":

> Protocol-relative links (PRL), also known as protocol-relative URLs
> (PRURL), are URLs that have no protocol specified. For example,
> `//example.com` will use the protocol of the current page, typically
> HTTP or HTTPS

However that's not what we use for HTTP+HTTPS mirrors, we use URLs that have only a host and a path. I'm still looking for the right term for that, if any...