### PR TITLE
Ensure trailing slash fallback url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/etix/mirrorbits/core"
+	"github.com/etix/mirrorbits/utils"
 	"github.com/op/go-logging"
 	"gopkg.in/yaml.v3"
 )
@@ -174,6 +175,9 @@ func ReloadConfig() error {
 	}
 	if c.RepositoryScanInterval < 0 {
 		c.RepositoryScanInterval = 0
+	}
+	for i := range c.Fallbacks {
+		c.Fallbacks[i].URL = utils.NormalizeURL(c.Fallbacks[i].URL)
 	}
 	for _, rule := range c.AllowOutdatedFiles {
 		if len(rule.Prefix) > 0 && rule.Prefix[0] != '/' {

--- a/config/config.go
+++ b/config/config.go
@@ -163,7 +163,7 @@ func ReloadConfig() error {
 	if c.WeightDistributionRange <= 0 {
 		return fmt.Errorf("WeightDistributionRange must be > 0")
 	}
-	if !isInSlice(c.OutputMode, []string{"auto", "json", "redirect"}) {
+	if !utils.IsInSlice(c.OutputMode, []string{"auto", "json", "redirect"}) {
 		return fmt.Errorf("Config: outputMode can only be set to 'auto', 'json' or 'redirect'")
 	}
 	if c.Repository == "" {
@@ -265,14 +265,4 @@ func testSentinelsEq(a, b []sentinels) bool {
 	}
 
 	return true
-}
-
-//DUPLICATE
-func isInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }

--- a/http/selection.go
+++ b/http/selection.go
@@ -87,13 +87,13 @@ func (h DefaultEngine) Selection(ctx *Context, cache *mirrors.Cache, fileInfo *f
 
 		if m.Distance <= closestMirror*GetConfig().WeightDistributionRange {
 			score := (float32(baseScore) - m.Distance)
-			if !utils.IsPrimaryCountry(clientInfo, m.CountryFields) {
+			if !network.IsPrimaryCountry(clientInfo, m.CountryFields) {
 				score /= 2
 			}
 			m.ComputedScore += int(score)
-		} else if utils.IsPrimaryCountry(clientInfo, m.CountryFields) {
+		} else if network.IsPrimaryCountry(clientInfo, m.CountryFields) {
 			m.ComputedScore += int(float32(baseScore) - (m.Distance * 5))
-		} else if utils.IsAdditionalCountry(clientInfo, m.CountryFields) {
+		} else if network.IsAdditionalCountry(clientInfo, m.CountryFields) {
 			m.ComputedScore += int(float32(baseScore) - closestMirror)
 		}
 

--- a/network/utils.go
+++ b/network/utils.go
@@ -42,3 +42,27 @@ func ExtractRemoteIP(XForwardedFor string) string {
 	}
 	return ""
 }
+
+// IsPrimaryCountry returns true if the clientInfo country is the primary country
+func IsPrimaryCountry(clientInfo GeoIPRecord, list []string) bool {
+	if !clientInfo.IsValid() {
+		return false
+	}
+	if len(list) > 0 && list[0] == clientInfo.CountryCode {
+		return true
+	}
+	return false
+}
+
+// IsAdditionalCountry returns true if the clientInfo country is in list
+func IsAdditionalCountry(clientInfo GeoIPRecord, list []string) bool {
+	if !clientInfo.IsValid() {
+		return false
+	}
+	for i, b := range list {
+		if i > 0 && b == clientInfo.CountryCode {
+			return true
+		}
+	}
+	return false
+}

--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -35,3 +35,49 @@ func TestExtractRemoteIP(t *testing.T) {
 		t.Fatalf("Expected '192.168.0.1', got %s", r)
 	}
 }
+
+func TestIsPrimaryCountry(t *testing.T) {
+	var b bool
+	list := []string{"FR", "DE", "GR"}
+
+	clientInfo := GeoIPRecord{
+		CountryCode: "FR",
+	}
+
+	b = IsPrimaryCountry(clientInfo, list)
+	if !b {
+		t.Fatal("Expected true, got false")
+	}
+
+	clientInfo = GeoIPRecord{
+		CountryCode: "GR",
+	}
+
+	b = IsPrimaryCountry(clientInfo, list)
+	if b {
+		t.Fatal("Expected false, got true")
+	}
+}
+
+func TestIsAdditionalCountry(t *testing.T) {
+	var b bool
+	list := []string{"FR", "DE", "GR"}
+
+	clientInfo := GeoIPRecord{
+		CountryCode: "FR",
+	}
+
+	b = IsAdditionalCountry(clientInfo, list)
+	if b {
+		t.Fatal("Expected false, got true")
+	}
+
+	clientInfo = GeoIPRecord{
+		CountryCode: "GR",
+	}
+
+	b = IsAdditionalCountry(clientInfo, list)
+	if !b {
+		t.Fatal("Expected true, got false")
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/etix/mirrorbits/core"
-	"github.com/etix/mirrorbits/network"
 )
 
 const (
@@ -89,30 +88,6 @@ func IsInSlice(a string, list []string) bool {
 		if b == a {
 			return true
 		}
-	}
-	return false
-}
-
-// IsAdditionalCountry returns true if the clientInfo country is in list
-func IsAdditionalCountry(clientInfo network.GeoIPRecord, list []string) bool {
-	if !clientInfo.IsValid() {
-		return false
-	}
-	for i, b := range list {
-		if i > 0 && b == clientInfo.CountryCode {
-			return true
-		}
-	}
-	return false
-}
-
-// IsPrimaryCountry returns true if the clientInfo country is the primary country
-func IsPrimaryCountry(clientInfo network.GeoIPRecord, list []string) bool {
-	if !clientInfo.IsValid() {
-		return false
-	}
-	if len(list) > 0 && list[0] == clientInfo.CountryCode {
-		return true
 	}
 	return false
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/etix/mirrorbits/core"
-	"github.com/etix/mirrorbits/network"
 )
 
 func TestHasAnyPrefix(t *testing.T) {
@@ -98,52 +97,6 @@ func TestIsInSlice(t *testing.T) {
 		t.Fatal("Expected false, got true")
 	}
 	b = IsInSlice("", list)
-	if b {
-		t.Fatal("Expected false, got true")
-	}
-}
-
-func TestIsAdditionalCountry(t *testing.T) {
-	var b bool
-	list := []string{"FR", "DE", "GR"}
-
-	clientInfo := network.GeoIPRecord{
-		CountryCode: "FR",
-	}
-
-	b = IsAdditionalCountry(clientInfo, list)
-	if b {
-		t.Fatal("Expected false, got true")
-	}
-
-	clientInfo = network.GeoIPRecord{
-		CountryCode: "GR",
-	}
-
-	b = IsAdditionalCountry(clientInfo, list)
-	if !b {
-		t.Fatal("Expected true, got false")
-	}
-}
-
-func TestIsPrimaryCountry(t *testing.T) {
-	var b bool
-	list := []string{"FR", "DE", "GR"}
-
-	clientInfo := network.GeoIPRecord{
-		CountryCode: "FR",
-	}
-
-	b = IsPrimaryCountry(clientInfo, list)
-	if !b {
-		t.Fatal("Expected true, got false")
-	}
-
-	clientInfo = network.GeoIPRecord{
-		CountryCode: "GR",
-	}
-
-	b = IsPrimaryCountry(clientInfo, list)
 	if b {
 		t.Fatal("Expected false, got true")
 	}


### PR DESCRIPTION
Normalize URL for fallback mirrors, to ensure it ends with a trailing slash. One less papercut for mirrorbits users.