### PR TITLE
Updated OpenStreetMap tile server URL

### DIFF
--- a/templates/mirrorlist.html
+++ b/templates/mirrorlist.html
@@ -138,7 +138,7 @@
 
     <script>
         var map = L.map('map').setView([20,37], 2);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: 'Data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>, map rendering <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
         }).addTo(map);
 

--- a/templates/mirrorstats.html
+++ b/templates/mirrorstats.html
@@ -103,7 +103,7 @@
 
     <script>
         var map = L.map('map').setView([20,37], 2);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
         }).addTo(map);
 


### PR DESCRIPTION
OpenStreetMap has updated documentation to use tile.openstreetmap.org in-place of {a|b|c}.tile.openstreetmap.org. Read more at https://github.com/openstreetmap/operations/issues/737 and https://operations.osmfoundation.org/policies/tiles/