### PR TITLE
add option for extra HTTP headers containing checksums

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,7 @@ type Configuration struct {
 	CheckInterval           int        `yaml:"CheckInterval"`
 	RepositoryScanInterval  int        `yaml:"RepositoryScanInterval"`
 	MaxLinkHeaders          int        `yaml:"MaxLinkHeaders"`
+	CheckSumHeaders         bool       `yaml:"CheckSumHeaders"`
 	FixTimezoneOffsets      bool       `yaml:"FixTimezoneOffsets"`
 	Hashes                  hashing    `yaml:"Hashes"`
 	DisallowRedirects       bool       `yaml:"DisallowRedirects"`

--- a/http/pagerenderer.go
+++ b/http/pagerenderer.go
@@ -5,6 +5,8 @@ package http
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,6 +90,22 @@ func (w *RedirectRenderer) Write(ctx *Context, results *mirrors.Results) (status
 					countryCode = strings.ToLower(m.CountryFields[0])
 				}
 				ctx.ResponseWriter().Header().Add("Link", fmt.Sprintf("<%s>; rel=duplicate; pri=%d; geo=%s", m.AbsoluteURL+path, i+1, countryCode))
+			}
+		}
+
+		// Generate checksum headers
+		if GetConfig().CheckSumHeaders {
+			if len(results.FileInfo.Md5) > 0 {
+				md5, _ := hex.DecodeString(results.FileInfo.Md5)
+				ctx.ResponseWriter().Header().Add("Content-MD5", fmt.Sprintf("%s", base64.StdEncoding.EncodeToString(md5)))
+			}
+			if len(results.FileInfo.Sha1) > 0 {
+				sha1, _ := hex.DecodeString(results.FileInfo.Sha1)
+				ctx.ResponseWriter().Header().Add("Content-SHA1", fmt.Sprintf("%s", base64.StdEncoding.EncodeToString(sha1)))
+			}
+			if len(results.FileInfo.Sha256) > 0 {
+				sha256, _ := hex.DecodeString(results.FileInfo.Sha256)
+				ctx.ResponseWriter().Header().Add("Content-SHA256", fmt.Sprintf("%s", base64.StdEncoding.EncodeToString(sha256)))
 			}
 		}
 

--- a/mirrorbits.conf
+++ b/mirrorbits.conf
@@ -137,6 +137,10 @@
 ## Affected mirrors will need to be rescanned after enabling this feature.
 # FixTimezoneOffsets: false
 
+## Send Content-(MD5|SHA1|SHA256) headers
+## requires the hashing algorithm to be enabled
+# CheckSumHeaders: true
+
 ## List of mirrors to use as fallback which will be used in case mirrorbits
 ## is unable to answer a request because the database is unreachable.
 ## Note: Mirrorbits will redirect to one of these mirrors based on the user


### PR DESCRIPTION
adds an rfc1864 compatible content-md5 header and analog extensions for sha1 and sha256 if the option CheckSumHeaders is true the following extra http headers will be added:
  Content-Md5: I9rjdRkQr90tbzCzZtDy4A==
  Content-Sha1: kvbBunf6Il0/5oMcuItvYcaHN9c=
  Content-Sha256: ktVLJsGP3LWFWjCsQLAXtIWE1kd3b+bXyNWmoFbxvV0=