### PR TITLE
Use 'any' in place of 'interface{}'

### DIFF
--- a/database/redis.go
+++ b/database/redis.go
@@ -312,7 +312,7 @@ func (r *Redis) selectDB(c redis.Conn) (err error) {
 	return
 }
 
-func (r *Redis) logError(format string, args ...interface{}) {
+func (r *Redis) logError(format string, args ...any) {
 	if r.Failure() {
 		log.Debugf(format, args...)
 	} else {
@@ -424,7 +424,7 @@ func parseVersion(version string) int64 {
 	return result
 }
 
-func parseInfo(i interface{}, err error) (map[string]string, error) {
+func parseInfo(i any, err error) (map[string]string, error) {
 	v, err := redis.String(i, err)
 	if err != nil {
 		return nil, err

--- a/database/utils.go
+++ b/database/utils.go
@@ -64,11 +64,11 @@ func (e *NotReadyError) Err() error {
 	return NewNetTemporaryError()
 }
 
-func (e *NotReadyError) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
+func (e *NotReadyError) Do(commandName string, args ...any) (reply any, err error) {
 	return nil, NewNetTemporaryError()
 }
 
-func (e *NotReadyError) Send(commandName string, args ...interface{}) error {
+func (e *NotReadyError) Send(commandName string, args ...any) error {
 	return NewNetTemporaryError()
 }
 
@@ -76,6 +76,6 @@ func (e *NotReadyError) Flush() error {
 	return NewNetTemporaryError()
 }
 
-func (e *NotReadyError) Receive() (reply interface{}, err error) {
+func (e *NotReadyError) Receive() (reply any, err error) {
 	return nil, NewNetTemporaryError()
 }

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -172,14 +172,14 @@ func redisIsLoadingError() error {
 // A pair consisting of a redis command, and its expected result
 type mockedCmd struct {
 	Cmd []string
-	Res interface{}
+	Res any
 }
 
 // Register a list of mocked redis commands
 func mockCommands(mock *redigomock.Conn, commands []mockedCmd) {
 	for _, item := range commands {
 		// Craft arguments for mock.Command, then mock
-		args := []interface{}{}
+		args := []any{}
 		for _, arg := range item.Cmd[1:] {
 			args = append(args, arg)
 		}

--- a/mirrors/cache_test.go
+++ b/mirrors/cache_test.go
@@ -109,7 +109,7 @@ func TestCache_fetchFileInfo(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte(strconv.FormatInt(testfile.Size, 10)),
 		[]byte(testfile.ModTime.Format("2006-01-02 15:04:05.999999999 -0700 MST")),
 		[]byte(testfile.Sha1),
@@ -154,7 +154,7 @@ func TestCache_fetchFileInfo_non_existing(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte(""),
 		[]byte(""),
 		[]byte(""),
@@ -201,7 +201,7 @@ func TestCache_GetFileInfo(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte(strconv.FormatInt(testfile.Size, 10)),
 		[]byte(testfile.ModTime.Format("2006-01-02 15:04:05.999999999 -0700 MST")),
 		[]byte(testfile.Sha1),
@@ -251,7 +251,7 @@ func TestCache_GetFileInfo_non_existing(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfo := mock.Command("HMGET", "FILE_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte(""),
 		[]byte(""),
 		[]byte(""),
@@ -295,7 +295,7 @@ func TestCache_fetchFileMirrors(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFilemirrors := mock.Command("SMEMBERS", "FILEMIRRORS_"+filename).Expect([]interface{}{
+	cmdGetFilemirrors := mock.Command("SMEMBERS", "FILEMIRRORS_"+filename).Expect([]any{
 		[]byte("9"),
 		[]byte("2"),
 		[]byte("5"),
@@ -427,7 +427,7 @@ func TestCache_fetchFileInfoMirror(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFileinfomirror := mock.Command("HMGET", "FILEINFO_1_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfomirror := mock.Command("HMGET", "FILEINFO_1_"+testfile.Path, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte(strconv.FormatInt(testfile.Size, 10)),
 		[]byte(testfile.ModTime.String()),
 		[]byte(testfile.Sha1),
@@ -507,7 +507,7 @@ func TestCache_GetMirrors(t *testing.T) {
 		t.Fatalf("Error expected, mock command not yet registered")
 	}
 
-	cmdGetFilemirrors := mock.Command("SMEMBERS", "FILEMIRRORS_"+filename).Expect([]interface{}{
+	cmdGetFilemirrors := mock.Command("SMEMBERS", "FILEMIRRORS_"+filename).Expect([]any{
 		[]byte("1"),
 		[]byte("2"),
 	})
@@ -524,7 +524,7 @@ func TestCache_GetMirrors(t *testing.T) {
 		"longitude": "0.1275",
 	})
 
-	cmdGetFileinfomirrorM1 := mock.Command("HMGET", "FILEINFO_1_"+filename, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfomirrorM1 := mock.Command("HMGET", "FILEINFO_1_"+filename, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte("44000"),
 		[]byte(""),
 		[]byte(""),
@@ -532,7 +532,7 @@ func TestCache_GetMirrors(t *testing.T) {
 		[]byte(""),
 	})
 
-	cmdGetFileinfomirrorM2 := mock.Command("HMGET", "FILEINFO_2_"+filename, "size", "modTime", "sha1", "sha256", "md5").Expect([]interface{}{
+	cmdGetFileinfomirrorM2 := mock.Command("HMGET", "FILEINFO_2_"+filename, "size", "modTime", "sha1", "sha256", "md5").Expect([]any{
 		[]byte("44000"),
 		[]byte(""),
 		[]byte(""),

--- a/mirrors/logs.go
+++ b/mirrors/logs.go
@@ -304,7 +304,7 @@ func ReadLogs(r *database.Redis, mirrorid, max int) ([]string, error) {
 	outputs := make([]string, 0, len(lines))
 
 	for _, line := range lines {
-		var objmap map[string]interface{}
+		var objmap map[string]any
 		err = json.Unmarshal([]byte(line), &objmap)
 		if err != nil {
 			log.Warningf("Unable to parse mirror log line: %s", err)

--- a/mirrors/mirrors.go
+++ b/mirrors/mirrors.go
@@ -261,7 +261,7 @@ func SetMirrorState(r *database.Redis, id int, proto Protocol, state bool, reaso
 		return err
 	}
 
-	var args []interface{}
+	var args []any
 	args = append(args, key, upField, state, reasonField, reason)
 
 	if state != previousState {
@@ -310,7 +310,7 @@ func (r *Redirects) Allowed() bool {
 }
 
 // MarshalYAML converts internal values to YAML
-func (r Redirects) MarshalYAML() (interface{}, error) {
+func (r Redirects) MarshalYAML() (any, error) {
 	var b *bool
 	switch r {
 	case 1:
@@ -325,7 +325,7 @@ func (r Redirects) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML converts YAML to internal values
-func (r *Redirects) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Redirects) UnmarshalYAML(unmarshal func(any) error) error {
 	var b *bool
 	if err := unmarshal(&b); err != nil {
 		return err
@@ -348,12 +348,12 @@ type Time struct {
 }
 
 // RedisArg serialize the time.Time object
-func (t Time) RedisArg() interface{} {
+func (t Time) RedisArg() any {
 	return t.UTC().Unix()
 }
 
 // RedisScan deserialize the time.Time object
-func (t *Time) RedisScan(src interface{}) (err error) {
+func (t *Time) RedisScan(src any) (err error) {
 	switch src := src.(type) {
 	case int64:
 		t.Time = time.Unix(src, 0)

--- a/network/geoip.go
+++ b/network/geoip.go
@@ -51,7 +51,7 @@ type GeoIPRecord struct {
 
 // Geolocalizer is an interface representing a GeoIP library
 type Geolocalizer interface {
-	Lookup(ipAddress net.IP, result interface{}) error
+	Lookup(ipAddress net.IP, result any) error
 }
 
 // NewGeoIP instanciates a new instance of GeoIP

--- a/network/geoip_test.go
+++ b/network/geoip_test.go
@@ -124,7 +124,7 @@ func TestGeoIPRecord_IsValid(t *testing.T) {
 type GeoIPMockCity struct {
 }
 
-func (g *GeoIPMockCity) Lookup(ipAddress net.IP, result interface{}) error {
+func (g *GeoIPMockCity) Lookup(ipAddress net.IP, result any) error {
 	var citydb CityDb
 	citydb.City.Names.En = "test1"
 	citydb.Country.Iso_Code = "test2"
@@ -141,7 +141,7 @@ func (g *GeoIPMockCity) Lookup(ipAddress net.IP, result interface{}) error {
 type GeoIPMockASN struct {
 }
 
-func (g *GeoIPMockASN) Lookup(ipAddress net.IP, result interface{}) error {
+func (g *GeoIPMockASN) Lookup(ipAddress net.IP, result any) error {
 	var asnDb ASNDb
 	asnDb.Autonomous_system_number = 42
 	asnDb.Autonomous_system_organization = "forty two"
@@ -151,7 +151,7 @@ func (g *GeoIPMockASN) Lookup(ipAddress net.IP, result interface{}) error {
 	return nil
 }
 
-func CopyStruct(src interface{}, dst interface{}) {
+func CopyStruct(src any, dst any) {
 	s := reflect.Indirect(reflect.ValueOf(src))
 	d := reflect.Indirect(reflect.ValueOf(dst))
 	CopyStructRec(s, d)

--- a/rpc/interceptors.go
+++ b/rpc/interceptors.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func StreamInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func StreamInterceptor(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	if err := authorize(stream.Context()); err != nil {
 		return err
 	}
@@ -21,7 +21,7 @@ func StreamInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.Str
 	return handler(srv, stream)
 }
 
-func UnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func UnaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	if err := authorize(ctx); err != nil {
 		return nil, err
 	}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -186,11 +186,11 @@ func (c *CLI) List(ctx context.Context, in *empty.Empty) (*MirrorListReply, erro
 
 	for _, e := range res {
 		var mirror mirrors.Mirror
-		res, ok := e.([]interface{})
+		res, ok := e.([]any)
 		if !ok {
 			return nil, errors.New("typecast failed")
 		}
-		err = redis.ScanStruct([]interface{}(res), &mirror)
+		err = redis.ScanStruct([]any(res), &mirror)
 		if err != nil {
 			return nil, errors.Wrap(err, "scan struct failed")
 		}
@@ -719,11 +719,11 @@ func (c *CLI) StatsFile(ctx context.Context, in *StatsFileRequest) (*StatsFileRe
 	}
 
 	for _, res := range stats {
-		line, ok := res.([]interface{})
+		line, ok := res.([]any)
 		if !ok {
 			return nil, errors.Wrap(err, "typecast failed")
 		} else {
-			stats := []interface{}(line)
+			stats := []any(line)
 			for i := 0; i < len(stats); i += 2 {
 				path, _ := redis.String(stats[i], nil)
 				matched := re.MatchString(path)

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -155,7 +155,7 @@ func Scan(typ core.ScannerType, r *database.Redis, c *mirrors.Cache, url string,
 	s.ScannerCommit()
 
 	// Get the list of files no more present on this mirror
-	var toremove []interface{}
+	var toremove []any
 	toremove, err = redis.Values(conn.Do("SDIFF", filesKey, s.filesTmpKey))
 	if err != nil {
 		return nil, err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -126,7 +126,7 @@ func ElapsedSec(lastTimestamp int64, elapsedTime int64) bool {
 }
 
 // Plural returns a single 's' if there are more than one value
-func Plural(value interface{}) string {
+func Plural(value any) string {
 	n, ok := value.(int)
 	if ok && n > 1 || n < -1 {
 		return "s"


### PR DESCRIPTION
Modernize the code a bit and use 'any' in place of 'interface{}'.

For reference, the type any was introduced with Go 1.18, cf. https://go.dev/doc/go1.18#language.

This commit was created with the following command:

    find -name '*.go' | grep -v 'pb\.go' | xargs sed -i 's/interface{}/any/g'