### PR TITLE
Stop using io/ioutil, deprecated in Go 1.16

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -656,7 +656,7 @@ func (c *cli) CmdEdit(args ...string) error {
 	out, err := yaml.Marshal(mirror)
 
 	// Open a temporary file
-	f, err := ioutil.TempFile(os.TempDir(), "edit")
+	f, err := os.CreateTemp("", "edit")
 	if err != nil {
 		log.Fatal("Cannot create temporary file:", err)
 	}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -683,7 +682,7 @@ reopen:
 	}
 
 	// Read the file back
-	out, err = ioutil.ReadFile(f.Name())
+	out, err = os.ReadFile(f.Name())
 	if err != nil {
 		log.Fatal("Cannot read file", f.Name())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -141,7 +140,7 @@ func ReloadConfig() error {
 		}
 	}
 
-	content, err := ioutil.ReadFile(core.ConfigFile)
+	content, err := os.ReadFile(core.ConfigFile)
 	if err != nil {
 		fmt.Println("Configuration could not be found.\n\tUse -config <path>")
 		os.Exit(1)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -5,7 +5,6 @@ package http
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -233,22 +232,13 @@ type testContext struct {
 }
 
 // Prepare a test, return the context
-func prepareTest(filenames []string) (testContext, error) {
+func prepareTest(t *testing.T, filenames []string) (testContext, error) {
 	// Create a temporary directory for test data
-	testDir, err := ioutil.TempDir("", "mirrorbits-tests")
-	if err != nil {
-		return testContext{}, err
-	}
-
-	defer func() {
-		if err != nil {
-			os.RemoveAll(testDir)
-		}
-	}()
+	testDir := t.TempDir()
 
 	// Create the repo directory, along with dummy files
 	repoDir := testDir + "/repo"
-	err = os.Mkdir(repoDir, 0755)
+	err := os.Mkdir(repoDir, 0755)
 	if err != nil {
 		return testContext{}, err
 	}
@@ -310,13 +300,6 @@ func prepareTest(filenames []string) (testContext, error) {
 	}, nil
 }
 
-// Cleanup after a test is done
-func cleanupTest(ctx testContext) {
-	if ctx.TestDir != "" {
-		os.RemoveAll(ctx.TestDir)
-	}
-}
-
 // Test 4xx return codes from MirrorHandler.
 //
 // Those HTTP codes are triggered when the file requested doesn't even exist in
@@ -324,11 +307,10 @@ func cleanupTest(ctx testContext) {
 // there's no need to mock redis commands.
 func TestMirrorHandler4xx(t *testing.T) {
 	// Prepare
-	ctx, err := prepareTest([]string{})
+	ctx, err := prepareTest(t, []string{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanupTest(ctx)
 
 	noHeader := map[string]string{}
 
@@ -460,11 +442,10 @@ var mockedCmds304 = [][]mockedCmd{
 // unexpected.
 func TestMirrorHandler3xx(t *testing.T) {
 	// Prepare
-	ctx, err := prepareTest([]string{testFile})
+	ctx, err := prepareTest(t, []string{testFile})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanupTest(ctx)
 
 	// Define tests
 	tests := map[string]struct {

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -62,7 +62,7 @@ func TestIsTerminal(t *testing.T) {
 		t.Fatalf("The current terminal is supposed to support colors")
 	}
 
-	f, err := ioutil.TempFile("", "mirrorbits-tests")
+	f, err := os.CreateTemp("", "mirrorbits-tests")
 	if err != nil {
 		t.Errorf("Unable to create a temporary file: %s", err.Error())
 		return
@@ -103,7 +103,7 @@ func TestReloadRuntimeLogs(t *testing.T) {
 	}
 
 	/* */
-	f, err := ioutil.TempFile("", "mirrorbits-tests")
+	f, err := os.CreateTemp("", "mirrorbits-tests")
 	if err != nil {
 		t.Errorf("Unable to create a temporary file: %s", err.Error())
 		return

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -144,12 +143,7 @@ func TestReloadRuntimeLogs(t *testing.T) {
 }
 
 func TestOpenLogFile(t *testing.T) {
-	path, err := ioutil.TempDir("", "mirrorbits-tests")
-	if err != nil {
-		t.Errorf("Unable to create temporary directory: %s", err.Error())
-		return
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	f, newfile, err := openLogFile(path + "/test1.log")
 	if err != nil {

--- a/logs/logs_test.go
+++ b/logs/logs_test.go
@@ -6,6 +6,7 @@ package logs
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -127,7 +128,7 @@ func TestReloadRuntimeLogs(t *testing.T) {
 	testString := "Testing42"
 	log.Error(testString)
 
-	buf, _ := ioutil.ReadAll(f)
+	buf, _ := io.ReadAll(f)
 	if !strings.Contains(string(buf), testString) {
 		t.Fatalf("The log doesn't contain the string %s", testString)
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -6,7 +6,6 @@ package process
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -170,7 +169,7 @@ func WritePidFile() {
 
 	// Get our own PID and write it
 	pid := strconv.Itoa(os.Getpid())
-	if err := ioutil.WriteFile(p, []byte(pid), 0644); err != nil {
+	if err := os.WriteFile(p, []byte(pid), 0644); err != nil {
 		log.Errorf("Unable to write pid file: %v", err)
 	}
 }
@@ -191,7 +190,7 @@ func RemovePidFile() {
 
 // GetRemoteProcPid gets the pid as it appears in the pid file (maybe not ours)
 func GetRemoteProcPid() int {
-	b, err := ioutil.ReadFile(GetPidLocation())
+	b, err := os.ReadFile(GetPidLocation())
 	if err != nil {
 		return -1
 	}


### PR DESCRIPTION
Most of the changes are drop-in replacements, so it's a fairly straightforward MR.