### PR TITLE
No longer call os.Exit from TestMain

### DIFF
--- a/daemon/cluster_test.go
+++ b/daemon/cluster_test.go
@@ -5,7 +5,6 @@ package daemon
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -21,7 +20,7 @@ func TestMain(m *testing.M) {
 	SetConfiguration(&Configuration{
 		RedisDB: 42,
 	})
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestStart(t *testing.T) {

--- a/http/selection_test.go
+++ b/http/selection_test.go
@@ -5,7 +5,6 @@ package http
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ func TestMain(m *testing.M) {
 	SetConfiguration(&Configuration{
 		FixTimezoneOffsets: false,
 	})
-	os.Exit(m.Run())
+	m.Run()
 }
 
 // Helper to check the results of the Filter function on a single mirror


### PR DESCRIPTION
This is no longer necessary with Go 1.15 and above, cf. https://tip.golang.org/doc/go1.15#testingpkgtesting