### PR TITLE
Drop github.com/pkg/errors and use Golang errors package from standard library

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -27,7 +28,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/op/go-logging"
-	"github.com/pkg/errors"
 	"golang.org/x/term"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1198,7 +1198,7 @@ func (c *cli) CmdVersion(args ...string) error {
 	reply, err := client.GetVersion(ctx, &empty.Empty{})
 	if err != nil {
 		s := status.Convert(err)
-		return errors.Wrap(s.Err(), "version error")
+		return fmt.Errorf("version error: %w", s.Err())
 	}
 
 	if reply.Version != "" {

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -5,6 +5,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -22,7 +23,6 @@ import (
 	"github.com/etix/mirrorbits/utils"
 	"github.com/gomodule/redigo/redis"
 	"github.com/op/go-logging"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -170,7 +170,7 @@ func (m *monitor) MonitorLoop() {
 		err := m.scanRepository()
 		if err != nil {
 			if i == 0 {
-				log.Errorf("%+v", errors.Wrap(err, "unable to scan the local repository"))
+				log.Errorf("%+v", fmt.Errorf("unable to scan the local repository: %w", err))
 			}
 			return err
 		}
@@ -182,14 +182,14 @@ func (m *monitor) MonitorLoop() {
 		ids, err := m.mirrorsID()
 		if err != nil {
 			if i == 0 {
-				log.Errorf("%+v", errors.Wrap(err, "unable to retrieve the mirror list"))
+				log.Errorf("%+v", fmt.Errorf("unable to retrieve the mirror list: %w", err))
 			}
 			return err
 		}
 		err = m.syncMirrorList(ids...)
 		if err != nil {
 			if i == 0 {
-				log.Errorf("%+v", errors.Wrap(err, "unable to sync the list of mirrors"))
+				log.Errorf("%+v", fmt.Errorf("unable to sync the list of mirrors: %w", err))
 			}
 			return err
 		}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -433,7 +433,8 @@ func (m *monitor) syncLoop() {
 			go func() {
 				err := m.trace.GetLastUpdate(mir.Mirror)
 				if err != nil && err != scan.ErrNoTrace {
-					if numError, ok := err.(*strconv.NumError); ok {
+					var numError *strconv.NumError
+					if errors.As(err, &numError) {
 						if numError.Err == strconv.ErrSyntax {
 							log.Warningf("[%s] parsing trace file failed: %s is not a valid timestamp", mir.Name, strconv.Quote(numError.Num))
 							return
@@ -550,7 +551,8 @@ func (m *monitor) healthCheckDo(mirror *mirrors.Mirror, url string, file string,
 	}
 
 	if err != nil {
-		if opErr, ok := err.(*net.OpError); ok {
+		var opErr *net.OpError
+		if errors.As(err, &opErr) {
 			log.Debugf("Op: %s | Net: %s | Addr: %s | Err: %s | Temporary: %t", opErr.Op, opErr.Net, opErr.Addr, opErr.Error(), opErr.Temporary())
 		}
 		reason := "Unreachable"

--- a/database/redis.go
+++ b/database/redis.go
@@ -386,7 +386,7 @@ again:
 			time.Sleep(100 * time.Millisecond)
 			goto again
 		} else if err != nil {
-			log.Fatalf("Upgrade failed: %+v", err)
+			log.Fatalf("Upgrade failed: %v", err)
 		}
 		log.Infof("Database upgrade successful (took %s), starting normally", time.Since(t).Round(time.Millisecond))
 	}

--- a/database/v1/version1.go
+++ b/database/v1/version1.go
@@ -9,7 +9,6 @@ import (
 	"github.com/etix/mirrorbits/core"
 	"github.com/etix/mirrorbits/database/interfaces"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 // NewUpgraderV1 upgrades the database from version 0 to 1
@@ -110,19 +109,19 @@ func (v *Version1) CreateMirrorIndex(a *actions) (map[int]string, error) {
 	// Get the v0 list of mirrors
 	mirrors, err := redis.Strings(conn.Do("LRANGE", "MIRRORS", "0", "-1"))
 	if err != nil {
-		return m, errors.WithStack(err)
+		return m, err
 	}
 
 	for _, name := range mirrors {
 		// Create a unique ID for the current mirror
 		id, err := redis.Int(conn.Do("INCR", "LAST_MID"))
 		if err != nil {
-			return m, errors.WithStack(err)
+			return m, err
 		}
 
 		// Assign the ID to the current mirror
 		if _, err = conn.Do("HSET", "V1_MIRRORS", id, name); err != nil {
-			return m, errors.WithStack(err)
+			return m, err
 		}
 
 		m[id] = name
@@ -145,7 +144,7 @@ func (v *Version1) RenameKeys(a *actions, m map[int]string) error {
 		if err == redis.ErrNil || IsErrNoSuchKey(err) {
 			continue
 		} else if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		// Rename the FILEINFO_<name>_<file> keys
@@ -162,7 +161,7 @@ func (v *Version1) RenameKeys(a *actions, m map[int]string) error {
 	// Get the list of files in the local repo
 	files, err := redis.Strings(conn.Do("SMEMBERS", "FILES"))
 	if err != nil && err != redis.ErrNil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	// Rename the keys within FILEMIRRORS_*
@@ -170,7 +169,7 @@ func (v *Version1) RenameKeys(a *actions, m map[int]string) error {
 		// Get the list of mirrors having each file
 		names, err := redis.Strings(conn.Do("SMEMBERS", fmt.Sprintf("FILEMIRRORS_%s", file)))
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		for _, name := range names {
@@ -188,7 +187,7 @@ func (v *Version1) RenameKeys(a *actions, m map[int]string) error {
 			conn.Send("SADD", fmt.Sprintf("V1_FILEMIRRORS_%s", file), id)
 		}
 		if err := conn.Flush(); err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		// Mark the key for renaming
@@ -207,14 +206,14 @@ func (v *Version1) FixMirrorID(a *actions, m map[int]string) error {
 	for id, name := range m {
 		err := CopyKey(conn, fmt.Sprintf("MIRROR_%s", name), fmt.Sprintf("V1_MIRROR_%d", id))
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		conn.Send("HMSET", fmt.Sprintf("V1_MIRROR_%d", id), "ID", id, "name", name)
 		a.rename[fmt.Sprintf("V1_MIRROR_%d", id)] = fmt.Sprintf("MIRROR_%d", id)
 		a.delete = append(a.delete, fmt.Sprintf("MIRROR_%s", name))
 	}
 	if err := conn.Flush(); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -226,7 +225,7 @@ func (v *Version1) RenameStats(a *actions, m map[int]string) error {
 
 	keys, err := redis.Strings(conn.Do("KEYS", "STATS_MIRROR_*"))
 	if err != nil && err != redis.ErrNil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	for _, key := range keys {
@@ -237,7 +236,7 @@ func (v *Version1) RenameStats(a *actions, m map[int]string) error {
 
 		stats, err := redis.StringMap(conn.Do("HGETALL", key))
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		for identifier, value := range stats {
@@ -258,7 +257,7 @@ func (v *Version1) RenameStats(a *actions, m map[int]string) error {
 			a.rename["V1_"+key] = key
 		}
 		if err := conn.Flush(); err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 	}
 

--- a/database/v2/version2.go
+++ b/database/v2/version2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/etix/mirrorbits/core"
 	"github.com/etix/mirrorbits/database/interfaces"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 // NewUpgraderV2 upgrades the database from version 1 to 2
@@ -77,7 +76,7 @@ func (v *Version2) UpdateMirrors(a *actions) error {
 	// Get the list of mirrors
 	keys, err := redis.Strings(conn.Do("KEYS", "MIRROR_*"))
 	if err != nil && err != redis.ErrNil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	// Iterate on mirrors
@@ -86,20 +85,20 @@ func (v *Version2) UpdateMirrors(a *actions) error {
 		key := "V2_" + keyProd
 		err := CopyKey(conn, keyProd, key)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		// Get the http url
 		url, err := redis.String(conn.Do("HGET", key, "http"))
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		// Get the status. Note that the key might not exist if ever
 		// the mirror was never enabled or scanned successfully.
 		up, err := redis.Bool(conn.Do("HGET", key, "up"))
 		if err != nil && err != redis.ErrNil {
-			return errors.WithStack(err)
+			return err
 		}
 		upExists := true
 		if err == redis.ErrNil {
@@ -109,7 +108,7 @@ func (v *Version2) UpdateMirrors(a *actions) error {
 		// Get the excluded reason. As above: the key might not exist.
 		reason, err := redis.String(conn.Do("HGET", key, "excludeReason"))
 		if err != nil && err != redis.ErrNil {
-			return errors.WithStack(err)
+			return err
 		}
 		reasonExists := true
 		if err == redis.ErrNil {
@@ -146,7 +145,7 @@ func (v *Version2) UpdateMirrors(a *actions) error {
 		// Finalize the transaction
 		_, err = conn.Do("EXEC")
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		// Mark the key for renaming

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gomodule/redigo v0.0.0-20181026001555-e8fc0692a7e2
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/oschwald/maxminddb-golang v1.5.0
-	github.com/pkg/errors v0.8.1
 	github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1
 	github.com/youtube/vitess v0.0.0-20181105031612-54855ec7b369
 	golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0C
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/oschwald/maxminddb-golang v1.5.0 h1:rmyoIV6z2/s9TCJedUuDiKht2RN12LWJ1L7iRGtWY64=
 github.com/oschwald/maxminddb-golang v1.5.0/go.mod h1:3jhIUymTJ5VREKyIhWm66LJiQt04F0UCDdodShpjWsY=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/http/http.go
+++ b/http/http.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"math/rand"
@@ -77,7 +78,8 @@ func HTTPServer(redis *database.Redis, cache *mirrors.Cache) *HTTP {
 
 	// Load the GeoIP databases
 	if err := h.geoip.LoadGeoIP(); err != nil {
-		if gerr, ok := err.(network.GeoIPError); ok {
+		var gerr network.GeoIPError
+		if errors.As(err, &gerr) {
 			for _, e := range gerr.Errors {
 				log.Critical(e.Error())
 			}
@@ -264,7 +266,8 @@ func (h *HTTP) mirrorHandler(w http.ResponseWriter, r *http.Request, ctx *Contex
 
 	/* Handle errors */
 	fallback := false
-	if _, ok := err.(net.Error); ok || len(mlist) == 0 {
+	var netErr net.Error
+	if errors.As(err, &netErr) || len(mlist) == 0 {
 		/* Handle fallbacks */
 		fallbacks := GetConfig().Fallbacks
 		if len(fallbacks) > 0 {
@@ -402,7 +405,8 @@ func (h *HTTP) LoadTemplates(name string) (t *template.Template, err error) {
 		filepath.Clean(GetConfig().Templates+"/base.html"),
 		filepath.Clean(fmt.Sprintf("%s/%s.html", GetConfig().Templates, name)))
 	if err != nil {
-		if e, ok := err.(*os.PathError); ok {
+		var e *os.PathError
+		if errors.As(err, &e) {
 			log.Fatalf(fmt.Sprintf("Cannot load template %s: %s", e.Path, e.Err.Error()))
 		} else {
 			log.Fatal(err.Error())

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/etix/mirrorbits/process"
 	"github.com/etix/mirrorbits/rpc"
 	"github.com/op/go-logging"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -55,7 +54,7 @@ func main() {
 		/* Setup RPC */
 		rpcs := new(rpc.CLI)
 		if err := rpcs.Start(); err != nil {
-			log.Fatal(errors.Wrap(err, "rpc error"))
+			log.Fatal(fmt.Errorf("rpc error: %w", err))
 		}
 
 		/* Connect to the database */

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -278,7 +278,7 @@ func (c *CLI) GeoUpdateMirror(ctx context.Context, in *MirrorIDRequest) (*GeoUpd
 
 	geo := network.NewGeoIP()
 	if err := geo.LoadGeoIP(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	geoRec := geo.GetRecord(ip)
@@ -346,7 +346,7 @@ func (c *CLI) AddMirror(ctx context.Context, in *Mirror) (*AddMirrorReply, error
 
 	geo := network.NewGeoIP()
 	if err := geo.LoadGeoIP(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	geoRec := geo.GetRecord(ip)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -621,7 +621,8 @@ func (c *CLI) ScanMirror(ctx context.Context, in *ScanMirrorRequest) (*ScanMirro
 		defer wg.Done()
 		err := trace.GetLastUpdate(mirror)
 		if err != nil && err != scan.ErrNoTrace {
-			if numError, ok := err.(*strconv.NumError); ok {
+			var numError *strconv.NumError
+			if errors.As(err, &numError) {
 				if numError.Err == strconv.ErrSyntax {
 					//log.Warningf("[%s] parsing trace file failed: %s is not a valid timestamp", mirror.Name, strconv.Quote(numError.Num))
 					return

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -26,7 +27,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -126,7 +126,7 @@ func (c *CLI) MatchMirror(ctx context.Context, in *MatchRequest) (*MatchReply, e
 
 	mirrors, err := c.redis.GetListOfMirrors()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't fetch the list of mirrors")
+		return nil, fmt.Errorf("can't fetch the list of mirrors: %w", err)
 	}
 
 	reply := &MatchReply{}
@@ -169,7 +169,7 @@ func (c *CLI) List(ctx context.Context, in *empty.Empty) (*MirrorListReply, erro
 
 	mirrorsIDs, err := c.redis.GetListOfMirrors()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't fetch the list of mirrors")
+		return nil, fmt.Errorf("can't fetch the list of mirrors: %w", err)
 	}
 
 	conn.Send("MULTI")
@@ -179,7 +179,7 @@ func (c *CLI) List(ctx context.Context, in *empty.Empty) (*MirrorListReply, erro
 
 	res, err := redis.Values(conn.Do("EXEC"))
 	if err != nil {
-		return nil, errors.Wrap(err, "database error")
+		return nil, fmt.Errorf("database error: %w", err)
 	}
 
 	reply := &MirrorListReply{}
@@ -192,7 +192,7 @@ func (c *CLI) List(ctx context.Context, in *empty.Empty) (*MirrorListReply, erro
 		}
 		err = redis.ScanStruct([]any(res), &mirror)
 		if err != nil {
-			return nil, errors.Wrap(err, "scan struct failed")
+			return nil, fmt.Errorf("scan struct failed: %w", err)
 		}
 		m, err := MirrorToRPC(&mirror)
 		if err != nil {
@@ -263,7 +263,7 @@ func (c *CLI) GeoUpdateMirror(ctx context.Context, in *MirrorIDRequest) (*GeoUpd
 		u, err = url.Parse("http://" + mirror.HttpURL)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "can't parse http url")
+		return nil, fmt.Errorf("can't parse http url: %w", err)
 	}
 
 	reply := &GeoUpdateMirrorReply{}
@@ -273,7 +273,7 @@ func (c *CLI) GeoUpdateMirror(ctx context.Context, in *MirrorIDRequest) (*GeoUpd
 		reply.Warnings = append(reply.Warnings,
 			"Warning: the hostname returned more than one address. Assuming they're sharing the same location.")
 	} else if err != nil {
-		return nil, errors.Wrap(err, "IP lookup failed")
+		return nil, fmt.Errorf("IP lookup failed: %w", err)
 	}
 
 	geo := network.NewGeoIP()
@@ -331,7 +331,7 @@ func (c *CLI) AddMirror(ctx context.Context, in *Mirror) (*AddMirrorReply, error
 		u, err = url.Parse("http://" + mirror.HttpURL)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "can't parse http url")
+		return nil, fmt.Errorf("can't parse http url: %w", err)
 	}
 
 	reply := &AddMirrorReply{}
@@ -341,7 +341,7 @@ func (c *CLI) AddMirror(ctx context.Context, in *Mirror) (*AddMirrorReply, error
 		reply.Warnings = append(reply.Warnings,
 			"Warning: the hostname returned more than one address. Assuming they're sharing the same location.")
 	} else if err != nil {
-		return nil, errors.Wrap(err, "IP lookup failed")
+		return nil, fmt.Errorf("IP lookup failed: %w", err)
 	}
 
 	geo := network.NewGeoIP()
@@ -429,7 +429,7 @@ func (c *CLI) setMirror(mirror *mirrors.Mirror) error {
 
 	mirrorsIDs, err := c.redis.GetListOfMirrors()
 	if err != nil {
-		return errors.Wrap(err, "can't fetch the list of mirrors")
+		return fmt.Errorf("can't fetch the list of mirrors: %w", err)
 	}
 
 	isUpdate := false
@@ -447,7 +447,7 @@ func (c *CLI) setMirror(mirror *mirrors.Mirror) error {
 		// Generate a new ID
 		mirror.ID, err = redis.Int(conn.Do("INCR", "LAST_MID"))
 		if err != nil {
-			return errors.Wrap(err, "failed creating a new id")
+			return fmt.Errorf("failed creating a new id: %w", err)
 		}
 	}
 
@@ -505,7 +505,7 @@ func (c *CLI) setMirror(mirror *mirrors.Mirror) error {
 
 	_, err = conn.Do("EXEC")
 	if err != nil {
-		return errors.Wrap(err, "couldn't save the mirror configuration")
+		return fmt.Errorf("couldn't save the mirror configuration: %w", err)
 	}
 
 	// Publish update
@@ -536,13 +536,13 @@ func (c *CLI) RemoveMirror(ctx context.Context, in *MirrorIDRequest) (*empty.Emp
 	// First disable the mirror
 	err = mirrors.DisableMirror(c.redis, int(in.ID))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to disable the mirror")
+		return nil, fmt.Errorf("unable to disable the mirror: %w", err)
 	}
 
 	// Get all files supported by the given mirror
 	files, err := redis.Strings(conn.Do("SMEMBERS", fmt.Sprintf("MIRRORFILES_%d", in.ID)))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to fetch the file list")
+		return nil, fmt.Errorf("unable to fetch the file list: %w", err)
 	}
 
 	conn.Send("MULTI")
@@ -568,7 +568,7 @@ func (c *CLI) RemoveMirror(ctx context.Context, in *MirrorIDRequest) (*empty.Emp
 
 	_, err = conn.Do("EXEC")
 	if err != nil {
-		return nil, errors.Wrap(err, "operation failed")
+		return nil, fmt.Errorf("operation failed: %w", err)
 	}
 
 	// Publish update
@@ -666,7 +666,7 @@ func (c *CLI) ScanMirror(ctx context.Context, in *ScanMirrorRequest) (*ScanMirro
 	// Finally enable the mirror if requested
 	if err == nil && in.AutoEnable == true {
 		if err := mirrors.EnableMirror(c.redis, mirror.ID); err != nil {
-			return nil, errors.Wrap(err, "couldn't enable the mirror")
+			return nil, fmt.Errorf("couldn't enable the mirror: %w", err)
 		}
 		reply.Enabled = true
 	}
@@ -711,7 +711,7 @@ func (c *CLI) StatsFile(ctx context.Context, in *StatsFileRequest) (*StatsFileRe
 
 	stats, err := redis.Values(conn.Do("EXEC"))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't fetch stats")
+		return nil, fmt.Errorf("can't fetch stats: %w", err)
 	}
 
 	reply := &StatsFileReply{
@@ -721,7 +721,7 @@ func (c *CLI) StatsFile(ctx context.Context, in *StatsFileRequest) (*StatsFileRe
 	for _, res := range stats {
 		line, ok := res.([]any)
 		if !ok {
-			return nil, errors.Wrap(err, "typecast failed")
+			return nil, fmt.Errorf("typecast failed: %w", err)
 		} else {
 			stats := []any(line)
 			for i := 0; i < len(stats); i += 2 {
@@ -772,13 +772,13 @@ func (c *CLI) StatsMirror(ctx context.Context, in *StatsMirrorRequest) (*StatsMi
 
 	stats, err := redis.Strings(conn.Do("EXEC"))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't fetch stats")
+		return nil, fmt.Errorf("can't fetch stats: %w", err)
 	}
 
 	// Fetch the mirror struct
 	m, err := redis.Values(conn.Do("HGETALL", fmt.Sprintf("MIRROR_%d", in.ID)))
 	if err != nil {
-		return nil, errors.WithMessage(err, "can't fetch mirror")
+		return nil, fmt.Errorf("can't fetch mirror: %w", err)
 	}
 
 	reply := &StatsMirrorReply{}
@@ -786,12 +786,12 @@ func (c *CLI) StatsMirror(ctx context.Context, in *StatsMirrorRequest) (*StatsMi
 	var mirror mirrors.Mirror
 	err = redis.ScanStruct(m, &mirror)
 	if err != nil {
-		return nil, errors.Wrap(err, "stats error")
+		return nil, fmt.Errorf("stats error: %w", err)
 	}
 
 	reply.Mirror, err = MirrorToRPC(&mirror)
 	if err != nil {
-		return nil, errors.Wrap(err, "stats error")
+		return nil, fmt.Errorf("stats error: %w", err)
 	}
 
 	for i := 0; i < len(stats); i += 2 {
@@ -811,7 +811,7 @@ func (c *CLI) GetMirrorLogs(ctx context.Context, in *GetMirrorLogsRequest) (*Get
 
 	lines, err := mirrors.ReadLogs(c.redis, int(in.ID), int(in.MaxResults))
 	if err != nil {
-		return nil, errors.Wrap(err, "mirror logs error")
+		return nil, fmt.Errorf("mirror logs error: %w", err)
 	}
 
 	return &GetMirrorLogsReply{Line: lines}, nil


### PR DESCRIPTION
github.com/pkg/errors is mostly obsolete, and the last relevant commit was in 2020: https://github.com/pkg/errors/commits/master/

In the meantime, Golang's errors package got better, and now that we raised the baseline to Go 1,18, it is a suitable replacement. 

It just lacks `errors.WithStack()`, but I think we can just stop using it.