### PR TITLE
Replace redis command HMSET (deprecated) with HSET

### DIFF
--- a/database/v1/version1.go
+++ b/database/v1/version1.go
@@ -208,7 +208,7 @@ func (v *Version1) FixMirrorID(a *actions, m map[int]string) error {
 		if err != nil {
 			return err
 		}
-		conn.Send("HMSET", fmt.Sprintf("V1_MIRROR_%d", id), "ID", id, "name", name)
+		conn.Send("HSET", fmt.Sprintf("V1_MIRROR_%d", id), "ID", id, "name", name)
 		a.rename[fmt.Sprintf("V1_MIRROR_%d", id)] = fmt.Sprintf("MIRROR_%d", id)
 		a.delete = append(a.delete, fmt.Sprintf("MIRROR_%s", name))
 	}

--- a/mirrors/mirrors.go
+++ b/mirrors/mirrors.go
@@ -211,7 +211,7 @@ func SetMirrorEnabled(r *database.Redis, id int, state bool) error {
 	defer conn.Close()
 
 	key := fmt.Sprintf("MIRROR_%d", id)
-	_, err := conn.Do("HMSET", key, "enabled", state)
+	_, err := conn.Do("HSET", key, "enabled", state)
 
 	// Publish update
 	if err == nil {
@@ -268,7 +268,7 @@ func SetMirrorState(r *database.Redis, id int, proto Protocol, state bool, reaso
 		args = append(args, "stateSince", time.Now().Unix())
 	}
 
-	_, err = conn.Do("HMSET", args...)
+	_, err = conn.Do("HSET", args...)
 
 	if err == nil {
 		// Publish update

--- a/mirrors/mirrors_test.go
+++ b/mirrors/mirrors_test.go
@@ -384,14 +384,14 @@ func TestByExcludeReason_Less(t *testing.T) {
 func TestEnableMirror(t *testing.T) {
 	mock, conn := PrepareRedisTest()
 
-	cmdEnable := mock.Command("HMSET", "MIRROR_1", "enabled", true).Expect("ok")
+	cmdEnable := mock.Command("HSET", "MIRROR_1", "enabled", true).Expect("ok")
 	EnableMirror(conn, 1)
 
 	if mock.Stats(cmdEnable) != 1 {
 		t.Fatalf("Mirror not enabled")
 	}
 
-	mock.Command("HMSET", "MIRROR_1", "enabled", true).ExpectError(redis.Error("blah"))
+	mock.Command("HSET", "MIRROR_1", "enabled", true).ExpectError(redis.Error("blah"))
 	if EnableMirror(conn, 1) == nil {
 		t.Fatalf("Error expected")
 	}
@@ -400,14 +400,14 @@ func TestEnableMirror(t *testing.T) {
 func TestDisableMirror(t *testing.T) {
 	mock, conn := PrepareRedisTest()
 
-	cmdDisable := mock.Command("HMSET", "MIRROR_1", "enabled", false).Expect("ok")
+	cmdDisable := mock.Command("HSET", "MIRROR_1", "enabled", false).Expect("ok")
 	DisableMirror(conn, 1)
 
 	if mock.Stats(cmdDisable) != 1 {
 		t.Fatalf("Mirror not enabled")
 	}
 
-	mock.Command("HMSET", "MIRROR_1", "enabled", false).ExpectError(redis.Error("blah"))
+	mock.Command("HSET", "MIRROR_1", "enabled", false).ExpectError(redis.Error("blah"))
 	if DisableMirror(conn, 1) == nil {
 		t.Fatalf("Error expected")
 	}
@@ -418,7 +418,7 @@ func TestSetMirrorEnabled(t *testing.T) {
 
 	cmdPublish := mock.Command("PUBLISH", string(database.MIRROR_UPDATE), redigomock.NewAnyData()).Expect("ok")
 
-	cmdEnable := mock.Command("HMSET", "MIRROR_1", "enabled", true).Expect("ok")
+	cmdEnable := mock.Command("HSET", "MIRROR_1", "enabled", true).Expect("ok")
 	SetMirrorEnabled(conn, 1, true)
 
 	if mock.Stats(cmdEnable) < 1 {
@@ -431,12 +431,12 @@ func TestSetMirrorEnabled(t *testing.T) {
 		t.Fatalf("Event MIRROR_UPDATE not published")
 	}
 
-	mock.Command("HMSET", "MIRROR_1", "enabled", true).ExpectError(redis.Error("blah"))
+	mock.Command("HSET", "MIRROR_1", "enabled", true).ExpectError(redis.Error("blah"))
 	if SetMirrorEnabled(conn, 1, true) == nil {
 		t.Fatalf("Error expected")
 	}
 
-	cmdDisable := mock.Command("HMSET", "MIRROR_1", "enabled", false).Expect("ok")
+	cmdDisable := mock.Command("HSET", "MIRROR_1", "enabled", false).Expect("ok")
 	SetMirrorEnabled(conn, 1, false)
 
 	if mock.Stats(cmdDisable) != 1 {
@@ -449,7 +449,7 @@ func TestSetMirrorEnabled(t *testing.T) {
 		t.Fatalf("Event MIRROR_UPDATE not published")
 	}
 
-	mock.Command("HMSET", "MIRROR_1", "enabled", false).ExpectError(redis.Error("blah"))
+	mock.Command("HSET", "MIRROR_1", "enabled", false).ExpectError(redis.Error("blah"))
 	if SetMirrorEnabled(conn, 1, false) == nil {
 		t.Fatalf("Error expected")
 	}
@@ -483,8 +483,8 @@ func TestSetMirrorState(t *testing.T) {
 	/* Set HTTP mirror up */
 
 	cmdPreviousState := mock.Command("HGET", "MIRROR_1", "httpUp").Expect(int64(0)).Expect(int64(1))
-	cmdStateSince := mock.Command("HMSET", "MIRROR_1", "httpUp", true, "httpDownReason", "test1", "stateSince", redigomock.NewAnyInt()).Expect("ok")
-	cmdState := mock.Command("HMSET", "MIRROR_1", "httpUp", true, "httpDownReason", "test2").Expect("ok")
+	cmdStateSince := mock.Command("HSET", "MIRROR_1", "httpUp", true, "httpDownReason", "test1", "stateSince", redigomock.NewAnyInt()).Expect("ok")
+	cmdState := mock.Command("HSET", "MIRROR_1", "httpUp", true, "httpDownReason", "test2").Expect("ok")
 
 	if err := SetMirrorState(conn, 1, HTTP, true, "test1"); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -521,7 +521,7 @@ func TestSetMirrorState(t *testing.T) {
 	/* Set HTTP mirror down */
 
 	cmdPreviousState = mock.Command("HGET", "MIRROR_1", "httpUp").Expect(int64(1))
-	cmdStateSince = mock.Command("HMSET", "MIRROR_1", "httpUp", false, "httpDownReason", "test3", "stateSince", redigomock.NewAnyInt()).Expect("ok")
+	cmdStateSince = mock.Command("HSET", "MIRROR_1", "httpUp", false, "httpDownReason", "test3", "stateSince", redigomock.NewAnyInt()).Expect("ok")
 
 	if err := SetMirrorState(conn, 1, HTTP, false, "test3"); err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -465,7 +465,7 @@ func (c *CLI) setMirror(mirror *mirrors.Mirror) error {
 
 	// Save the values back into redis
 	conn.Send("MULTI")
-	conn.Send("HMSET", fmt.Sprintf("MIRROR_%d", mirror.ID),
+	conn.Send("HSET", fmt.Sprintf("MIRROR_%d", mirror.ID),
 		"ID", mirror.ID,
 		"name", mirror.Name,
 		"http", mirror.HttpURL,
@@ -493,10 +493,10 @@ func (c *CLI) setMirror(mirror *mirrors.Mirror) error {
 
 	// Reset state to down for unsupported protocol
 	if strings.HasPrefix(mirror.HttpURL, "http://") {
-		conn.Send("HMSET", fmt.Sprintf("MIRROR_%d", mirror.ID),
+		conn.Send("HSET", fmt.Sprintf("MIRROR_%d", mirror.ID),
 			"httpsUp", false)
 	} else if strings.HasPrefix(mirror.HttpURL, "https://") {
-		conn.Send("HMSET", fmt.Sprintf("MIRROR_%d", mirror.ID),
+		conn.Send("HSET", fmt.Sprintf("MIRROR_%d", mirror.ID),
 			"httpUp", false)
 	}
 

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -236,7 +236,7 @@ func (s *scan) ScannerAddFile(f filedata) {
 
 	// Save the size of the current file found on this mirror
 	ik := fmt.Sprintf("FILEINFO_%d_%s", s.mirrorid, f.path)
-	s.conn.Send("HMSET", ik, "size", f.size, "modTime", f.modTime)
+	s.conn.Send("HSET", ik, "size", f.size, "modTime", f.modTime)
 
 	// Publish update
 	database.SendPublish(s.conn, database.MIRROR_FILE_UPDATE, fmt.Sprintf("%d %s", s.mirrorid, f.path))
@@ -265,7 +265,7 @@ func (s *scan) setLastSync(conn redis.Conn, id int, protocol core.ScannerType, p
 			precision = core.Precision(time.Second)
 		}
 
-		conn.Send("HMSET", fmt.Sprintf("MIRROR_%d", id),
+		conn.Send("HSET", fmt.Sprintf("MIRROR_%d", id),
 			"lastSuccessfulSync", now,
 			"lastSuccessfulSyncProtocol", protocol,
 			"lastSuccessfulSyncPrecision", precision)
@@ -372,7 +372,7 @@ warn:
 finish:
 	// Store the offset in the database
 	key := fmt.Sprintf("MIRROR_%d", s.mirrorid)
-	_, err = s.conn.Do("HMSET", key, "tzoffset", ms)
+	_, err = s.conn.Do("HSET", key, "tzoffset", ms)
 	if err != nil {
 		return
 	}
@@ -532,7 +532,7 @@ func ScanSource(r *database.Redis, forceRehash bool, stop <-chan struct{}) (err 
 	// Create/Update the files' hash keys with the fresh infos
 	conn.Send("MULTI")
 	for _, e := range sourceFiles {
-		conn.Send("HMSET", fmt.Sprintf("FILE_%s", e.path),
+		conn.Send("HSET", fmt.Sprintf("FILE_%s", e.path),
 			"size", e.size,
 			"modTime", e.modTime,
 			"sha1", e.sha1,


### PR DESCRIPTION
HMSET is deprecated since Redis 4.0 [1] (released in June 2017), and should be replaced with HSET.

[1]: https://redis.io/docs/latest/commands/hset/