### PR TITLE
rpc: fix MatchMirror substring ambiguity for exact-match names

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -129,18 +129,40 @@ func (c *CLI) MatchMirror(ctx context.Context, in *MatchRequest) (*MatchReply, e
 		return nil, fmt.Errorf("can't fetch the list of mirrors: %w", err)
 	}
 
-	reply := &MatchReply{}
+	reply := &MatchReply{
+		Mirrors: matchMirrorsByPattern(mirrors, in.Pattern),
+	}
 
+	return reply, nil
+}
+
+// matchMirrorsByPattern returns the mirrors whose name contains pattern
+// (case-insensitive). If exactly one mirror name matches pattern exactly
+// (case-insensitive), only that mirror is returned, even if other mirror
+// names also contain pattern as a substring. This allows a mirror whose
+// name is a substring of other mirror names (e.g. "fcix.net" vs.
+// "mirror.fcix.net") to still be matched unambiguously.
+func matchMirrorsByPattern(mirrors map[int]string, pattern string) []*MirrorID {
+	lowerPattern := strings.ToLower(pattern)
+
+	var matches []*MirrorID
 	for id, name := range mirrors {
-		if strings.Contains(strings.ToLower(name), strings.ToLower(in.Pattern)) {
-			reply.Mirrors = append(reply.Mirrors, &MirrorID{
+		lowerName := strings.ToLower(name)
+		if lowerName == lowerPattern {
+			return []*MirrorID{{
+				ID:   int32(id),
+				Name: name,
+			}}
+		}
+		if strings.Contains(lowerName, lowerPattern) {
+			matches = append(matches, &MirrorID{
 				ID:   int32(id),
 				Name: name,
 			})
 		}
 	}
 
-	return reply, nil
+	return matches
 }
 
 func (c *CLI) ChangeStatus(ctx context.Context, in *ChangeStatusRequest) (*empty.Empty, error) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -136,12 +136,12 @@ func (c *CLI) MatchMirror(ctx context.Context, in *MatchRequest) (*MatchReply, e
 	return reply, nil
 }
 
-// matchMirrorsByPattern returns the mirrors whose name contains pattern
-// (case-insensitive). If exactly one mirror name matches pattern exactly
-// (case-insensitive), only that mirror is returned, even if other mirror
-// names also contain pattern as a substring. This allows a mirror whose
-// name is a substring of other mirror names (e.g. "fcix.net" vs.
-// "mirror.fcix.net") to still be matched unambiguously.
+// matchMirrorsByPattern returns a list of mirrors:
+// - if the pattern matches a mirror's name exactly, only that mirror is returned
+// - otherwise, all mirrors containing the pattern as a substring are returned
+// - all matches are case-insensitive
+// This allows a mirror whose name is a substring of other mirror names
+// (e.g. "fcix.net" vs. "mirror.fcix.net") to still be matched unambiguously.
 func matchMirrorsByPattern(mirrors map[int]string, pattern string) []*MirrorID {
 	lowerPattern := strings.ToLower(pattern)
 

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 Ludovic Fauvet
+// Copyright (c) 2026 Amit Mishra
 // Licensed under the MIT license
 
 package rpc
@@ -17,82 +17,75 @@ func names(mirrors []*MirrorID) []string {
 	return out
 }
 
-func TestMatchMirrorsByPatternExactMatchAmongSubstrings(t *testing.T) {
-	// Regression test for https://github.com/etix/mirrorbits/issues/134
-	// A mirror whose ID is a substring of other mirror names could never
-	// be matched on its own, because every other mirror containing it as
-	// a substring would also show up as a match.
-	mirrors := map[int]string{
-		1: "fcix.net",
-		2: "mirror.fcix.net",
-		3: "paducahix.mm.fcix.net",
-		4: "forksystems.mm.fcix.net",
+func TestMatchMirrorsByPattern(t *testing.T) {
+	// Regression test for https://github.com/videolabs/mirrorbits/issues/134
+	tests := []struct {
+		name    string
+		mirrors map[int]string
+		pattern string
+		want    []string
+	}{
+		{
+			name: "exact match takes priority over substring matches",
+			mirrors: map[int]string{
+				1: "fcix.net",
+				2: "mirror.fcix.net",
+				3: "paducahix.mm.fcix.net",
+				4: "forksystems.mm.fcix.net",
+			},
+			pattern: "fcix.net",
+			want:    []string{"fcix.net"},
+		},
+		{
+			name: "exact match is case-insensitive",
+			mirrors: map[int]string{
+				1: "FCIX.net",
+				2: "mirror.fcix.net",
+			},
+			pattern: "fcix.net",
+			want:    []string{"FCIX.net"},
+		},
+		{
+			name: "multiple substring matches returned when no exact match",
+			mirrors: map[int]string{
+				1: "mirror.fcix.net",
+				2: "paducahix.mm.fcix.net",
+			},
+			pattern: "fcix.net",
+			want:    []string{"mirror.fcix.net", "paducahix.mm.fcix.net"},
+		},
+		{
+			name: "no match returns empty",
+			mirrors: map[int]string{
+				1: "alpha",
+				2: "beta",
+			},
+			pattern: "gamma",
+			want:    nil,
+		},
+		{
+			name: "single substring match",
+			mirrors: map[int]string{
+				1: "mirror.example.com",
+				2: "other.example.org",
+			},
+			pattern: "example.com",
+			want:    []string{"mirror.example.com"},
+		},
 	}
 
-	got := matchMirrorsByPattern(mirrors, "fcix.net")
-	want := []string{"fcix.net"}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := names(matchMirrorsByPattern(tc.mirrors, tc.pattern))
 
-	if gotNames := names(got); len(gotNames) != len(want) || gotNames[0] != want[0] {
-		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
-	}
-}
-
-func TestMatchMirrorsByPatternExactMatchIsCaseInsensitive(t *testing.T) {
-	mirrors := map[int]string{
-		1: "FCIX.net",
-		2: "mirror.fcix.net",
-	}
-
-	got := matchMirrorsByPattern(mirrors, "fcix.net")
-	want := []string{"FCIX.net"}
-
-	if gotNames := names(got); len(gotNames) != len(want) || gotNames[0] != want[0] {
-		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
-	}
-}
-
-func TestMatchMirrorsByPatternMultipleSubstringMatches(t *testing.T) {
-	mirrors := map[int]string{
-		1: "mirror.fcix.net",
-		2: "paducahix.mm.fcix.net",
-	}
-
-	got := matchMirrorsByPattern(mirrors, "fcix.net")
-	want := []string{"mirror.fcix.net", "paducahix.mm.fcix.net"}
-
-	gotNames := names(got)
-	if len(gotNames) != len(want) {
-		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
-	}
-	for i := range want {
-		if gotNames[i] != want[i] {
-			t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
-		}
-	}
-}
-
-func TestMatchMirrorsByPatternNoMatch(t *testing.T) {
-	mirrors := map[int]string{
-		1: "alpha",
-		2: "beta",
-	}
-
-	got := matchMirrorsByPattern(mirrors, "gamma")
-	if len(got) != 0 {
-		t.Fatalf("matchMirrorsByPattern(%q) = %v, want empty", "gamma", names(got))
-	}
-}
-
-func TestMatchMirrorsByPatternSingleSubstringMatch(t *testing.T) {
-	mirrors := map[int]string{
-		1: "mirror.example.com",
-		2: "other.example.org",
-	}
-
-	got := matchMirrorsByPattern(mirrors, "example.com")
-	want := []string{"mirror.example.com"}
-
-	if gotNames := names(got); len(gotNames) != len(want) || gotNames[0] != want[0] {
-		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "example.com", gotNames, want)
+			if len(got) != len(tc.want) {
+				t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", tc.pattern, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", tc.pattern, got, tc.want)
+				}
+			}
+		})
 	}
 }

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2014-2019 Ludovic Fauvet
+// Licensed under the MIT license
+
+package rpc
+
+import (
+	"sort"
+	"testing"
+)
+
+func names(mirrors []*MirrorID) []string {
+	var out []string
+	for _, m := range mirrors {
+		out = append(out, m.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestMatchMirrorsByPatternExactMatchAmongSubstrings(t *testing.T) {
+	// Regression test for https://github.com/etix/mirrorbits/issues/134
+	// A mirror whose ID is a substring of other mirror names could never
+	// be matched on its own, because every other mirror containing it as
+	// a substring would also show up as a match.
+	mirrors := map[int]string{
+		1: "fcix.net",
+		2: "mirror.fcix.net",
+		3: "paducahix.mm.fcix.net",
+		4: "forksystems.mm.fcix.net",
+	}
+
+	got := matchMirrorsByPattern(mirrors, "fcix.net")
+	want := []string{"fcix.net"}
+
+	if gotNames := names(got); len(gotNames) != len(want) || gotNames[0] != want[0] {
+		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
+	}
+}
+
+func TestMatchMirrorsByPatternExactMatchIsCaseInsensitive(t *testing.T) {
+	mirrors := map[int]string{
+		1: "FCIX.net",
+		2: "mirror.fcix.net",
+	}
+
+	got := matchMirrorsByPattern(mirrors, "fcix.net")
+	want := []string{"FCIX.net"}
+
+	if gotNames := names(got); len(gotNames) != len(want) || gotNames[0] != want[0] {
+		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
+	}
+}
+
+func TestMatchMirrorsByPatternMultipleSubstringMatches(t *testing.T) {
+	mirrors := map[int]string{
+		1: "mirror.fcix.net",
+		2: "paducahix.mm.fcix.net",
+	}
+
+	got := matchMirrorsByPattern(mirrors, "fcix.net")
+	want := []string{"mirror.fcix.net", "paducahix.mm.fcix.net"}
+
+	gotNames := names(got)
+	if len(gotNames) != len(want) {
+		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
+	}
+	for i := range want {
+		if gotNames[i] != want[i] {
+			t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "fcix.net", gotNames, want)
+		}
+	}
+}
+
+func TestMatchMirrorsByPatternNoMatch(t *testing.T) {
+	mirrors := map[int]string{
+		1: "alpha",
+		2: "beta",
+	}
+
+	got := matchMirrorsByPattern(mirrors, "gamma")
+	if len(got) != 0 {
+		t.Fatalf("matchMirrorsByPattern(%q) = %v, want empty", "gamma", names(got))
+	}
+}
+
+func TestMatchMirrorsByPatternSingleSubstringMatch(t *testing.T) {
+	mirrors := map[int]string{
+		1: "mirror.example.com",
+		2: "other.example.org",
+	}
+
+	got := matchMirrorsByPattern(mirrors, "example.com")
+	want := []string{"mirror.example.com"}
+
+	if gotNames := names(got); len(gotNames) != len(want) || gotNames[0] != want[0] {
+		t.Fatalf("matchMirrorsByPattern(%q) = %v, want %v", "example.com", gotNames, want)
+	}
+}


### PR DESCRIPTION
## Problem

`mb edit <name>` (and other commands that resolve a mirror by name)
matches mirrors using a plain `strings.Contains` scan over all mirror
names. When a mirror's name happens to be a substring of one or more
other mirror names, it can never be addressed on its own: every mirror
whose name contains the pattern is reported as a match, so the CLI
always prints "Multiple match" and exits.

For example, given mirrors `fcix.net`, `mirror.fcix.net`, and
`paducahix.mm.fcix.net`, running `mb edit fcix.net` reports all three
as matches instead of resolving to the exact `fcix.net` mirror.

Fixes #134

## Fix

`MatchMirror`'s matching logic is extracted into a standalone,
testable function `matchMirrorsByPattern`. It now prefers a single
case-insensitive exact match over partial substring matches. If no
exact match exists, it falls back to the previous substring-match
behavior (including returning multiple matches when the pattern is
genuinely ambiguous).

## Testing

- Added `rpc/rpc_test.go` covering: the exact-match-among-substrings
  regression case from #134, case-insensitivity of the exact match,
  preserved multi-match behavior when no exact match exists, no-match,
  and a basic single-substring-match case.
- Verified the new test fails against the original `strings.Contains`-only
  logic and passes with the fix.
- `go build` / `go vet` clean for `GOOS=linux` (this repo's CI target);
  the local Windows dev environment can't compile the `process` package
  or the original `rpc/rpc.go` (`syscall.SIGUSR2` is Unix-only), which is
  a pre-existing platform limitation unrelated to this change.

This PR was written primarily by Claude Code; I reviewed the change and
ran the tests before submitting.